### PR TITLE
refactor(react-query): move data fetching hooks to react-query

### DIFF
--- a/src/context-selection/category-option-combo-selector-bar-item/use-category-combination.js
+++ b/src/context-selection/category-option-combo-selector-bar-item/use-category-combination.js
@@ -1,5 +1,4 @@
-import { useDataQuery } from '@dhis2/app-runtime'
-import { useEffect } from 'react'
+import { useQuery } from 'react-query'
 import { useDataSetId } from '../use-context-selection.js'
 
 const QUERY_CATEGORY_COMBINATION = {
@@ -16,22 +15,18 @@ const QUERY_CATEGORY_COMBINATION = {
 
 export default function useCategoryCombination() {
     const [dataSetId] = useDataSetId()
-    const { called, loading, error, refetch, data } = useDataQuery(
-        QUERY_CATEGORY_COMBINATION,
-        { lazy: true }
-    )
-
-    useEffect(() => {
-        if (dataSetId) {
-            refetch({ id: dataSetId })
-        }
-    }, [dataSetId])
+    const queryKey = [QUERY_CATEGORY_COMBINATION, { id: dataSetId }]
+    const {
+        isIdle,
+        isLoading: loading,
+        error,
+        data,
+    } = useQuery(queryKey, { enabled: !!dataSetId })
 
     return {
-        called,
+        called: !isIdle,
         loading,
         error,
-        refetch,
         data: data?.dataSet.categoryCombo,
     }
 }

--- a/src/context-selection/data-set-selector-bar-item/use-data-set.js
+++ b/src/context-selection/data-set-selector-bar-item/use-data-set.js
@@ -1,5 +1,4 @@
-import { useDataQuery } from '@dhis2/app-runtime'
-import { useEffect } from 'react'
+import { useQuery } from 'react-query'
 import { useDataSetId } from '../use-context-selection.js'
 
 const QUERY_DATA_SET = {
@@ -14,22 +13,19 @@ const QUERY_DATA_SET = {
 
 export default function useDataSet() {
     const [dataSetId] = useDataSetId()
-    const { called, loading, error, refetch, data } = useDataQuery(
-        QUERY_DATA_SET,
-        { lazy: true }
-    )
-
-    useEffect(() => {
-        if (dataSetId) {
-            refetch({ id: dataSetId })
-        }
-    }, [dataSetId])
+    const {
+        isIdle,
+        isLoading: loading,
+        error,
+        data,
+    } = useQuery([QUERY_DATA_SET, { id: dataSetId }], {
+        enabled: !!dataSetId,
+    })
 
     return {
-        called,
+        called: !isIdle,
         loading,
         error,
-        refetch,
         data: data?.dataSet,
     }
 }

--- a/src/context-selection/data-set-selector-bar-item/use-selectable-data-sets.js
+++ b/src/context-selection/data-set-selector-bar-item/use-selectable-data-sets.js
@@ -1,4 +1,4 @@
-import { useDataQuery } from '@dhis2/app-runtime'
+import { useQuery } from 'react-query'
 
 const QUERY_SELECTABLE_DATA_SETS = {
     dataSets: {
@@ -10,7 +10,11 @@ const QUERY_SELECTABLE_DATA_SETS = {
 }
 
 export default function useSelectableDataSets() {
-    const { loading, error, data } = useDataQuery(QUERY_SELECTABLE_DATA_SETS)
+    const {
+        isLoading: loading,
+        error,
+        data,
+    } = useQuery([QUERY_SELECTABLE_DATA_SETS])
 
     // @TODO: How to handle pages / large lists?
     // Nested as this is "page-able"

--- a/src/context-selection/org-unit-selector-bar-item/use-data-set-org-unit-paths.js
+++ b/src/context-selection/org-unit-selector-bar-item/use-data-set-org-unit-paths.js
@@ -1,5 +1,4 @@
-import { useDataQuery } from '@dhis2/app-runtime'
-import { useEffect } from 'react'
+import { useQuery } from 'react-query'
 import { useDataSetId } from '../use-context-selection.js'
 
 const QUERY_DATA_SET_ORG_UNIT_PATHS = {
@@ -14,16 +13,12 @@ const QUERY_DATA_SET_ORG_UNIT_PATHS = {
 
 export default function useDataSetOrgUnitPaths() {
     const [dataSetId] = useDataSetId()
-    const { loading, error, data, refetch } = useDataQuery(
-        QUERY_DATA_SET_ORG_UNIT_PATHS,
-        { lazy: true }
-    )
-
-    useEffect(() => {
-        if (dataSetId) {
-            refetch({ id: dataSetId })
-        }
-    }, [dataSetId])
+    const queryKey = [QUERY_DATA_SET_ORG_UNIT_PATHS, { id: dataSetId }]
+    const {
+        isLoading: loading,
+        error,
+        data,
+    } = useQuery(queryKey, { enabled: !!dataSetId })
 
     const dataSetOrgUnitPaths = data?.dataSet.organisationUnits.map(
         ({ path }) => path

--- a/src/context-selection/org-unit-selector-bar-item/use-organisation-unit.js
+++ b/src/context-selection/org-unit-selector-bar-item/use-organisation-unit.js
@@ -1,5 +1,4 @@
-import { useDataQuery } from '@dhis2/app-runtime'
-import { useEffect } from 'react'
+import { useQuery } from 'react-query'
 import { useOrgUnitId } from '../use-context-selection.js'
 
 const QUERY_ORG_UNIT = {
@@ -14,15 +13,12 @@ const QUERY_ORG_UNIT = {
 
 export default function useOrgUnit() {
     const [orgUnitId] = useOrgUnitId()
-    const { loading, error, refetch, data } = useDataQuery(QUERY_ORG_UNIT, {
-        lazy: true,
-    })
-
-    useEffect(() => {
-        if (orgUnitId) {
-            refetch({ id: orgUnitId })
-        }
-    }, [orgUnitId])
+    const queryKey = [QUERY_ORG_UNIT, { id: orgUnitId }]
+    const {
+        isLoading: loading,
+        error,
+        data,
+    } = useQuery(queryKey, { enabled: !!orgUnitId })
 
     const orgUnit = data?.orgUnit
 

--- a/src/context-selection/org-unit-selector-bar-item/use-user-org-units.js
+++ b/src/context-selection/org-unit-selector-bar-item/use-user-org-units.js
@@ -1,4 +1,4 @@
-import { useDataQuery } from '@dhis2/app-runtime'
+import { useQuery } from 'react-query'
 
 const QUERY_USER_ORG_UNITS = {
     orgUnits: {
@@ -10,7 +10,7 @@ const QUERY_USER_ORG_UNITS = {
 }
 
 export default function useUserOrgUnits() {
-    const { loading, error, data } = useDataQuery(QUERY_USER_ORG_UNITS)
+    const { isLoading: loading, error, data } = useQuery([QUERY_USER_ORG_UNITS])
     const userOrgUnits = data?.orgUnits.organisationUnits.map(({ id }) => id)
 
     return {

--- a/src/context-selection/period-selector-bar-item/use-data-set-period-type.js
+++ b/src/context-selection/period-selector-bar-item/use-data-set-period-type.js
@@ -1,5 +1,4 @@
-import { useDataQuery } from '@dhis2/app-runtime'
-import { useEffect } from 'react'
+import { useQuery } from 'react-query'
 import { useDataSetId } from '../use-context-selection.js'
 
 const QUERY_DATA_SET = {
@@ -14,15 +13,12 @@ const QUERY_DATA_SET = {
 
 export default function useDataSetPeriodType() {
     const [dataSetId] = useDataSetId()
-    const { loading, error, refetch, data } = useDataQuery(QUERY_DATA_SET, {
-        lazy: true,
-    })
-
-    useEffect(() => {
-        if (dataSetId) {
-            refetch({ id: dataSetId })
-        }
-    }, [dataSetId])
+    const queryKey = [QUERY_DATA_SET, { id: dataSetId }]
+    const {
+        isLoading: loading,
+        error,
+        data,
+    } = useQuery(queryKey, { enabled: !!dataSetId })
 
     const dataSetPeriodType = data?.dataSet.periodType
 

--- a/src/context-selection/section-filter-selector-bar-item/use-data-set-sections-info.js
+++ b/src/context-selection/section-filter-selector-bar-item/use-data-set-sections-info.js
@@ -1,5 +1,4 @@
-import { useDataQuery } from '@dhis2/app-runtime'
-import { useEffect } from 'react'
+import { useQuery } from 'react-query'
 import { useDataSetId } from '../use-context-selection.js'
 
 const QUERY_DATA_SET_SECTIONS_INFO = {
@@ -14,16 +13,13 @@ const QUERY_DATA_SET_SECTIONS_INFO = {
 
 export default function useDataSetSectionsInfo() {
     const [dataSetId] = useDataSetId()
-    const { called, loading, error, refetch, data } = useDataQuery(
-        QUERY_DATA_SET_SECTIONS_INFO,
-        { lazy: true }
-    )
-
-    useEffect(() => {
-        if (dataSetId) {
-            refetch({ id: dataSetId })
-        }
-    }, [dataSetId])
+    const queryKey = [QUERY_DATA_SET_SECTIONS_INFO, { id: dataSetId }]
+    const {
+        isIdle,
+        isLoading: loading,
+        error,
+        data,
+    } = useQuery(queryKey, { enabled: !!dataSetId })
 
     const dataSetSectionsInfo = data?.dataSet.sections.map(
         ({ id, displayName }) => ({
@@ -33,7 +29,7 @@ export default function useDataSetSectionsInfo() {
     )
 
     return {
-        called,
+        called: !isIdle,
         loading,
         error,
         data: dataSetSectionsInfo,


### PR DESCRIPTION
This refactors our hooks to use react-query directly, see: https://dhis2.slack.com/archives/C02NHB92S2H/p1640105370054600. The react-query specific code will be replaced by an app-runtime implementation, but since we don't have that yet we're using react-query in the meantime.

Follow-up:

- Set queryProvider defaults (see the defaults in the app-runtime). Things like automatic refresh on network reconnect, cache time, etc.
- Start work on offline functionality, optimistic updates, etc.

Docs:

- https://runtime.dhis2.nu/#/hooks/useDataEngine
- https://react-query.tanstack.com/reference/useQuery
- https://react-query.tanstack.com/guides/query-keys