### PR TITLE
feat: retry mutations and optimistic updates

### DIFF
--- a/src/data-workspace/data-entry-cell/data-entry-cell.js
+++ b/src/data-workspace/data-entry-cell/data-entry-cell.js
@@ -3,8 +3,9 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import { useField } from 'react-final-form'
-import { useMutation } from 'react-query'
+import { useQueryClient, useMutation } from 'react-query'
 import { useContextSelection } from '../../context-selection/index.js'
+import { dataValueQuery, useAttributeOptionCombo } from '../data-workspace.js'
 import { useMetadata } from '../metadata-context.js'
 import { getDataSetById } from '../selectors.js'
 import { useMutationFn } from '../use-mutation-fn.js'
@@ -22,6 +23,9 @@ const DATA_VALUE_MUTATION = {
 }
 
 export function DataEntryCell({ dataElement: de, categoryOptionCombo: coc }) {
+    const [{ dataSetId, orgUnitId, periodId }] = useContextSelection()
+    const attributeOptionComboId = useAttributeOptionCombo()
+
     // This field name results in this structure for the form data object:
     // { [deId]: { [cocId]: value } }
     const fieldName = `${de.id}.${coc.id}`
@@ -31,8 +35,73 @@ export function DataEntryCell({ dataElement: de, categoryOptionCombo: coc }) {
     const [lastSyncedValue, setLastSyncedValue] = useState(meta.initial)
     const { focusNext, focusPrev } = useFieldNavigation(fieldName)
 
+    const queryClient = useQueryClient()
     const mutationFn = useMutationFn(DATA_VALUE_MUTATION)
     const { mutate, isIdle, isLoading, isError } = useMutation(mutationFn, {
+        onMutate: async (newDataValue) => {
+            const dataValueQueryKey = [
+                dataValueQuery,
+                {
+                    dataSetId,
+                    periodId,
+                    orgUnitId,
+                    attributeOptionComboId,
+                },
+            ]
+
+            // Cancel any outgoing refetches (so they don't overwrite our optimistic update)
+            await queryClient.cancelQueries(dataValueQueryKey)
+
+            // Snapshot the previous value
+            const previousDataValues =
+                queryClient.getQueryData(dataValueQueryKey)
+
+            // Optimistically update to the new value
+            queryClient.setQueryData(dataValueQueryKey, (oldDataValues) => {
+                const newDataValues = { ...oldDataValues }
+
+                newDataValues.dataValues.dataValues =
+                    oldDataValues.dataValues.dataValues.map((dataValue) => {
+                        const {
+                            categoryOptionCombo,
+                            dataElement,
+                            orgUnit,
+                            period,
+                        } = dataValue
+                        const { co, de, ou, pe, value } = newDataValue
+                        const match =
+                            categoryOptionCombo === co &&
+                            dataElement === de &&
+                            orgUnit === ou &&
+                            period === pe
+
+                        if (!match) {
+                            return dataValue
+                        }
+
+                        return {
+                            ...dataValue,
+                            value,
+                        }
+                    })
+
+                return newDataValues
+            })
+
+            return { previousDataValues, dataValueQueryKey }
+        },
+        // If the mutation fails, use the context returned from onMutate to roll back
+        onError: (err, newDataValue, context) => {
+            queryClient.setQueryData(
+                context.dataValueQueryKey,
+                context.previousDataValues
+            )
+        },
+        // Always refetch after error or success
+        // eslint-disable-next-line max-params
+        onSettled: (newDataValue, error, variables, context) => {
+            queryClient.invalidateQueries(context.dataValueQueryKey)
+        },
         retry: 1,
     })
     const [dataEntryContext] = useContextSelection()

--- a/src/data-workspace/data-entry-cell/data-entry-cell.js
+++ b/src/data-workspace/data-entry-cell/data-entry-cell.js
@@ -1,12 +1,13 @@
-import { useDataMutation } from '@dhis2/app-runtime/build/cjs'
 import { IconMore16, colors } from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import { useField } from 'react-final-form'
+import { useMutation } from 'react-query'
 import { useContextSelection } from '../../context-selection/index.js'
 import { useMetadata } from '../metadata-context.js'
 import { getDataSetById } from '../selectors.js'
+import { useMutationFn } from '../use-mutation-fn.js'
 import styles from './data-entry-cell.module.css'
 import { getValidatorByValueType } from './field-validation.js'
 import { useFieldNavigation } from './use-field-navigation.js'
@@ -30,8 +31,10 @@ export function DataEntryCell({ dataElement: de, categoryOptionCombo: coc }) {
     const [lastSyncedValue, setLastSyncedValue] = useState(meta.initial)
     const { focusNext, focusPrev } = useFieldNavigation(fieldName)
 
-    const [mutate, { called, loading, error }] =
-        useDataMutation(DATA_VALUE_MUTATION)
+    const mutationFn = useMutationFn(DATA_VALUE_MUTATION)
+    const { mutate, isIdle, isLoading, isError } = useMutation(mutationFn, {
+        retry: 1,
+    })
     const [dataEntryContext] = useContextSelection()
     const { metadata } = useMetadata()
 
@@ -100,7 +103,7 @@ export function DataEntryCell({ dataElement: de, categoryOptionCombo: coc }) {
     // todo: implement other input types for different value types
     // todo: implement read-only cells
 
-    const synced = meta.valid && called && !loading && !error
+    const synced = meta.valid && !isIdle && !isLoading && !isError
     const inputStateClassName = meta.invalid
         ? styles.inputInvalid
         : synced
@@ -120,7 +123,7 @@ export function DataEntryCell({ dataElement: de, categoryOptionCombo: coc }) {
                     // disabled={true}
                 />
                 <div className={styles.topRightIndicator}>
-                    {loading ? (
+                    {isLoading ? (
                         <IconMore16 color={colors.grey700} />
                     ) : synced ? (
                         <div className={styles.topRightTriangle} />

--- a/src/data-workspace/data-workspace.js
+++ b/src/data-workspace/data-workspace.js
@@ -24,7 +24,7 @@ const query = {
     },
 }
 
-const dataValueQuery = {
+export const dataValueQuery = {
     dataValues: {
         resource: 'dataValueSets',
         params: ({
@@ -98,7 +98,7 @@ function mapDataValuesToFormInitialValues(dataValues) {
 
 // TODO: this should probably be handled by useContextSelection-hook
 // should not need this when api support CC and CP instead of cocId
-const useAttributeOptionCombo = () => {
+export const useAttributeOptionCombo = () => {
     const { available, metadata } = useMetadata()
     const [{ dataSetId, attributeOptionComboSelection }] = useContextSelection()
     const cocId = useMemo(() => {

--- a/src/data-workspace/use-data-value-mutation.js
+++ b/src/data-workspace/use-data-value-mutation.js
@@ -38,35 +38,42 @@ export const useDataValueMutation = () => {
                 queryClient.getQueryData(dataValueQueryKey)
 
             // Optimistically update to the new value
-            queryClient.setQueryData(dataValueQueryKey, (oldDataValues) => {
-                const newDataValues = { ...oldDataValues }
+            queryClient.setQueryData(dataValueQueryKey, () => {
+                const newDataValues =
+                    previousDataValues.dataValues.dataValues.map(
+                        (dataValue) => {
+                            const {
+                                categoryOptionCombo,
+                                dataElement,
+                                orgUnit,
+                                period,
+                            } = dataValue
+                            const { co, de, ou, pe, value } = newDataValue
+                            const match =
+                                categoryOptionCombo === co &&
+                                dataElement === de &&
+                                orgUnit === ou &&
+                                period === pe
 
-                newDataValues.dataValues.dataValues =
-                    oldDataValues.dataValues.dataValues.map((dataValue) => {
-                        const {
-                            categoryOptionCombo,
-                            dataElement,
-                            orgUnit,
-                            period,
-                        } = dataValue
-                        const { co, de, ou, pe, value } = newDataValue
-                        const match =
-                            categoryOptionCombo === co &&
-                            dataElement === de &&
-                            orgUnit === ou &&
-                            period === pe
+                            if (!match) {
+                                return dataValue
+                            }
 
-                        if (!match) {
-                            return dataValue
+                            return {
+                                ...dataValue,
+                                value,
+                            }
                         }
+                    )
 
-                        return {
-                            ...dataValue,
-                            value,
-                        }
-                    })
-
-                return newDataValues
+                // Ensure we don't mutate previousDataValues
+                return {
+                    ...previousDataValues,
+                    dataValues: {
+                        ...previousDataValues.dataValues,
+                        dataValues: newDataValues,
+                    },
+                }
             })
 
             return { previousDataValues, dataValueQueryKey }

--- a/src/data-workspace/use-data-value-mutation.js
+++ b/src/data-workspace/use-data-value-mutation.js
@@ -1,0 +1,88 @@
+import { useDataEngine } from '@dhis2/app-runtime'
+import { useQueryClient, useMutation } from 'react-query'
+import { useContextSelection } from '../context-selection/index.js'
+import { dataValueQuery, useAttributeOptionCombo } from './data-workspace.js'
+
+const DATA_VALUE_MUTATION = {
+    resource: 'dataValues',
+    type: 'create',
+    params: ({ ...params }) => ({ ...params }),
+}
+
+export const useDataValueMutation = () => {
+    const queryClient = useQueryClient()
+    const [{ dataSetId, orgUnitId, periodId }] = useContextSelection()
+    const attributeOptionComboId = useAttributeOptionCombo()
+    const engine = useDataEngine()
+
+    const dataValueQueryKey = [
+        dataValueQuery,
+        {
+            dataSetId,
+            periodId,
+            orgUnitId,
+            attributeOptionComboId,
+        },
+    ]
+    const mutationFn = (variables) =>
+        engine.mutate(DATA_VALUE_MUTATION, { variables })
+
+    return useMutation(mutationFn, {
+        // Optimistic update of the react-query cache
+        onMutate: async (newDataValue) => {
+            // Cancel any outgoing refetches (so they don't overwrite our optimistic update)
+            await queryClient.cancelQueries(dataValueQueryKey)
+
+            // Snapshot the previous value
+            const previousDataValues =
+                queryClient.getQueryData(dataValueQueryKey)
+
+            // Optimistically update to the new value
+            queryClient.setQueryData(dataValueQueryKey, (oldDataValues) => {
+                const newDataValues = { ...oldDataValues }
+
+                newDataValues.dataValues.dataValues =
+                    oldDataValues.dataValues.dataValues.map((dataValue) => {
+                        const {
+                            categoryOptionCombo,
+                            dataElement,
+                            orgUnit,
+                            period,
+                        } = dataValue
+                        const { co, de, ou, pe, value } = newDataValue
+                        const match =
+                            categoryOptionCombo === co &&
+                            dataElement === de &&
+                            orgUnit === ou &&
+                            period === pe
+
+                        if (!match) {
+                            return dataValue
+                        }
+
+                        return {
+                            ...dataValue,
+                            value,
+                        }
+                    })
+
+                return newDataValues
+            })
+
+            return { previousDataValues, dataValueQueryKey }
+        },
+        // If the mutation fails, use the context returned from onMutate to roll back
+        onError: (err, newDataValue, context) => {
+            queryClient.setQueryData(
+                context.dataValueQueryKey,
+                context.previousDataValues
+            )
+        },
+        // Always refetch after error or success
+        // eslint-disable-next-line max-params
+        onSettled: (newDataValue, error, variables, context) => {
+            queryClient.invalidateQueries(context.dataValueQueryKey)
+        },
+        retry: 1,
+    })
+}

--- a/src/data-workspace/use-mutation-fn.js
+++ b/src/data-workspace/use-mutation-fn.js
@@ -1,0 +1,7 @@
+import { useDataEngine } from '@dhis2/app-runtime'
+
+export const useMutationFn = (mutation) => {
+    const engine = useDataEngine()
+
+    return (variables) => engine.mutate(mutation, { variables })
+}

--- a/src/data-workspace/use-mutation-fn.js
+++ b/src/data-workspace/use-mutation-fn.js
@@ -1,7 +1,0 @@
-import { useDataEngine } from '@dhis2/app-runtime'
-
-export const useMutationFn = (mutation) => {
-    const engine = useDataEngine()
-
-    return (variables) => engine.mutate(mutation, { variables })
-}


### PR DESCRIPTION
- Enabled retry for cell mutations, which will retry in order once online
- Added optimistic updates for cell datavalue mutation

Follow-up:

- Implement optimistic updates for comments
- Cached mutations should only be removed after a server response for that mutation (i.e. success or server error). Otherwise they should persist (check the retry setting)
- Organize the data fetching hooks (so that the query doesn't change without the optimistic update adapting to that change, should probably colocate them)
- Could integrate the isPaused state for the mutation hook
- Keep only the last mutation for each item
- Add a global indicator for the amount of pending mutations
- Persist the query cache with the optimistic updates and the mutation cache
- Ensure that the optimistic updates won't be overwritten until the related mutation has settled

Docs:

- https://tkdodo.eu/blog/effective-react-query-keys
- https://react-query.tanstack.com/guides/optimistic-updates
- https://react-query.tanstack.com/guides/query-keys
- https://react-query.tanstack.com/reference/QueryClient#queryclientsetqueriesdata
- https://react-query.tanstack.com/guides/query-invalidation
- https://react-query.tanstack.com/guides/invalidations-from-mutations
- https://react-query.tanstack.com/guides/filters#query-filters
- https://react-query.tanstack.com/graphql
- https://github.com/tannerlinsley/react-query/discussions/1626#discussioncomment-938629
- https://github.com/tannerlinsley/react-query/discussions/1500#discussioncomment-229672
- https://github.com/tannerlinsley/react-query/discussions/2597#discussioncomment-1249036
- https://github.com/tannerlinsley/react-query/discussions/2734#discussioncomment-1398792
- https://github.com/tannerlinsley/react-query/discussions/1325
- https://github.com/tannerlinsley/react-query/discussions/1304