### PR TITLE
fix: reinitialize form better

### DIFF
--- a/src/data-workspace/data-entry-cell/final-form-wrapper.js
+++ b/src/data-workspace/data-entry-cell/final-form-wrapper.js
@@ -9,6 +9,7 @@ export function FinalFormWrapper({ children, initialValues }) {
                 console.log({ values, form })
             }}
             initialValues={initialValues}
+            keepDirtyOnReinitialize
         >
             {() => children}
         </Form>


### PR DESCRIPTION
Fixes an issue where refetching `dataValueSet` overwrites optimistically updated values. Also makes it faster to fire sequential mutations!

https://user-images.githubusercontent.com/49666798/150521904-59fa650a-b032-4a04-89f1-b63015102103.mov

