### PR TITLE
feat: disable datavaluesets query when there are active mutations

### DIFF
--- a/src/data-workspace/data-entry-cell/index.js
+++ b/src/data-workspace/data-entry-cell/index.js
@@ -1,3 +1,4 @@
 export { FinalFormWrapper } from './final-form-wrapper.js'
 export { DataEntryCell } from './data-entry-cell.js'
+export { DATA_VALUE_MUTATION_KEY } from './use-data-value-mutation.js'
 export { useActiveCell } from './use-active-cell.js'

--- a/src/data-workspace/data-entry-cell/use-data-value-mutation.js
+++ b/src/data-workspace/data-entry-cell/use-data-value-mutation.js
@@ -6,6 +6,8 @@ import {
     useAttributeOptionCombo,
 } from '../data-workspace.js'
 
+export const DATA_VALUE_MUTATION_KEY = 'DATA_VALUE_MUTATION_KEY'
+
 const DATA_VALUE_MUTATION = {
     resource: 'dataValues',
     type: 'create',
@@ -63,6 +65,8 @@ export const useDataValueMutation = () => {
         engine.mutate(DATA_VALUE_MUTATION, { variables })
 
     return useMutation(mutationFn, {
+        // Used to identify whether this mutation is running
+        mutationKey: DATA_VALUE_MUTATION_KEY,
         // Optimistic update of the react-query cache
         onMutate: async (newDataValue) => {
             // Cancel any outgoing refetches (so they don't overwrite our optimistic update)

--- a/src/data-workspace/data-workspace.js
+++ b/src/data-workspace/data-workspace.js
@@ -1,6 +1,6 @@
 import { CircularLoader } from '@dhis2/ui'
 import React, { useMemo } from 'react'
-import { useQuery } from 'react-query'
+import { useQuery, useIsMutating } from 'react-query'
 import { useContextSelection } from '../context-selection/index.js'
 import { useMetadata } from '../metadata/index.js'
 import {
@@ -8,7 +8,10 @@ import {
     getDataSetById,
     getCategoryComboById,
 } from '../metadata/selectors.js'
-import { FinalFormWrapper } from './data-entry-cell/index.js'
+import {
+    FinalFormWrapper,
+    DATA_VALUE_MUTATION_KEY,
+} from './data-entry-cell/index.js'
 import styles from './data-workspace.module.css'
 import { EntryForm } from './entry-form.js'
 
@@ -69,16 +72,25 @@ const metadataQuery = {
 const useDataValueSet = () => {
     const [{ dataSetId, orgUnitId, periodId }] = useContextSelection()
     const attributeOptionComboId = useAttributeOptionCombo()
+    const activeMutations = useIsMutating({
+        mutationKey: DATA_VALUE_MUTATION_KEY,
+    })
 
-    return useQuery([
-        dataValueSetQuery,
+    return useQuery(
+        [
+            dataValueSetQuery,
+            {
+                dataSetId,
+                periodId,
+                orgUnitId,
+                attributeOptionComboId,
+            },
+        ],
         {
-            dataSetId,
-            periodId,
-            orgUnitId,
-            attributeOptionComboId,
-        },
-    ])
+            // Only enable this query if there are no ongoing mutations
+            enabled: activeMutations === 0,
+        }
+    )
 }
 
 // Form value object structure: { [dataElementId]: { [cocId]: value } }


### PR DESCRIPTION
To prevent our optimistic update from being overwritten by automatic refetches this will disable queries affected by the mutations until all the mutations have settled. This, coupled with final form's https://final-form.org/docs/react-final-form/types/FormProps#keepdirtyonreinitialize should ensure that the optimistic updates remain intact.

https://github.com/tannerlinsley/react-query/discussions/2245#discussioncomment-704718