### PR TITLE
feat: add mutation status indicator

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-01-18T08:54:08.887Z\n"
-"PO-Revision-Date: 2022-01-18T08:54:08.887Z\n"
+"POT-Creation-Date: 2022-01-25T13:04:06.580Z\n"
+"PO-Revision-Date: 2022-01-25T13:04:06.580Z\n"
 
 msgid "Not authorized"
 msgstr "Not authorized"
@@ -17,6 +17,12 @@ msgid ""
 msgstr ""
 "You don't have access to the Data Approval App. Contact a system "
 "administrator to request access."
+
+msgid "There are {{ pendingMutations }} pending mutations"
+msgstr "There are {{ pendingMutations }} pending mutations"
+
+msgid "Synced"
+msgstr "Synced"
 
 msgid "Choose a data set"
 msgstr "Choose a data set"

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -7,6 +7,7 @@ import './app.css'
 import { ContextSelection } from '../context-selection/index.js'
 import { DataWorkspace } from '../data-workspace/index.js'
 import { Layout } from './layout/index.js'
+import { MutationIndicator } from './mutation-indicator/index.js'
 import useQueryClient from './use-query-client.js'
 
 /**
@@ -26,7 +27,7 @@ const App = () => {
                         header={<ContextSelection />}
                         main={<DataWorkspace />}
                         sidebar=""
-                        footer=""
+                        footer={<MutationIndicator />}
                         showFooter
                     />
                 </QueryParamProvider>

--- a/src/app/mutation-indicator/index.js
+++ b/src/app/mutation-indicator/index.js
@@ -1,0 +1,1 @@
+export { default as MutationIndicator } from './mutation-indicator.js'

--- a/src/app/mutation-indicator/mutation-indicator.js
+++ b/src/app/mutation-indicator/mutation-indicator.js
@@ -1,0 +1,25 @@
+import i18n from '@dhis2/d2-i18n'
+import { Tag, IconError16, IconCheckmarkCircle16 } from '@dhis2/ui'
+import React from 'react'
+import { useIsMutating } from 'react-query'
+
+const MutationIndicator = () => {
+    const pendingMutations = useIsMutating()
+    const message = pendingMutations
+        ? i18n.t('There are {{ pendingMutations }} pending mutations', {
+              pendingMutations,
+          })
+        : i18n.t('Synced')
+
+    return (
+        <Tag
+            icon={
+                pendingMutations ? <IconError16 /> : <IconCheckmarkCircle16 />
+            }
+        >
+            {message}
+        </Tag>
+    )
+}
+
+export default MutationIndicator


### PR DESCRIPTION
This adds a status indicator for the mutations. Shows the amount of pending mutations if there are any, otherwise will show that all changes have been synced. Placement and styling are just placeholder for now.