### PR TITLE
fix: remove query invalidation after mutations have settled

### DIFF
--- a/src/data-workspace/data-entry-cell/use-data-value-mutation.js
+++ b/src/data-workspace/data-entry-cell/use-data-value-mutation.js
@@ -128,11 +128,6 @@ export const useDataValueMutation = () => {
                 context.previousDataValueSet
             )
         },
-        // Always refetch after error or success
-        // eslint-disable-next-line max-params
-        onSettled: (newDataValue, error, variables, context) => {
-            queryClient.invalidateQueries(context.dataValueSetQueryKey)
-        },
         retry: 1,
     })
 }


### PR DESCRIPTION
This removes the related query invalidation on both success and error. I've left the query disabling when there are pending mutations as that still seems like a good setting to have.