### PR TITLE
fix(query-client): disable refetch on focus

### DIFF
--- a/src/app/use-query-client.js
+++ b/src/app/use-query-client.js
@@ -15,6 +15,7 @@ const useQueryClient = () => {
         defaultOptions: {
             queries: {
                 queryFn,
+                refetchOnWindowFocus: false,
             },
         },
     })

--- a/src/data-workspace/data-workspace.js
+++ b/src/data-workspace/data-workspace.js
@@ -155,7 +155,6 @@ export const DataWorkspace = () => {
 
     useQuery([metadataQuery], {
         staleTime: 60 * 24 * 1000,
-        refetchOnWindowFocus: false,
         onSuccess: (data) => setMetadata(data.metadata),
     })
 


### PR DESCRIPTION
In the spirit of reducing network chattiness, I've disabled `refetchOnWindowFocus`.

It's also mostly because it's annoying to see all the network traffic in the network\-tab when debugging.

We might want to disable `refetchOnReconnect` as well, but that might have some more implications, and it would be interesting to see how that behaves with the optimistic updates.