### PR TITLE
refactor(org unit selector): remove filtering by data set org units

### DIFF
--- a/src/context-selection/org-unit-selector-bar-item/org-unit-selector-bar-item.js
+++ b/src/context-selection/org-unit-selector-bar-item/org-unit-selector-bar-item.js
@@ -12,9 +12,7 @@ import {
 } from '../use-context-selection/index.js'
 import DebouncedSearchInput from './debounced-search-input.js'
 import DisabledTooltip from './disabled-tooltip.js'
-import getFilteredOrgUnitPaths from './get-filtered-org-unit-paths.js'
 import css from './org-unit-selector-bar-item.module.css'
-import useDataSetOrgUnitPaths from './use-data-set-org-unit-paths.js'
 import useExpandedState from './use-expanded-state.js'
 import useOrgUnitPathsByName from './use-org-unit-paths-by-name.js'
 import useOrgUnit from './use-organisation-unit.js'
@@ -66,16 +64,12 @@ export default function OrganisationUnitSetSelectorBarItem() {
     // lowest level, Task: Figure out if only the lowest levels should be
     // selectable, if the levels above are missing from the response or whether
     // all parent units are automatically selectable as well
-    const dataSetOrgUnitPaths = useDataSetOrgUnitPaths()
+    // const dataSetOrgUnitPaths = useDataSetOrgUnitPaths()
 
     const selectorBarItemValue = useSelectorBarItemValue()
     const selected = orgUnit.data ? [orgUnit.data.path] : []
     const disabled = !dataSetId
-    const filteredOrgUnitPaths = getFilteredOrgUnitPaths({
-        filter,
-        orgUnitPathsByName: orgUnitPathsByName.data,
-        dataSetOrgUnitPaths: dataSetOrgUnitPaths.data,
-    })
+    const filteredOrgUnitPaths = filter ? [] : orgUnitPathsByName.data
     const orgUnitPathsByNameLoading =
         // Either a filter has been set but the hook
         // hasn't been called yet

--- a/src/context-selection/org-unit-selector-bar-item/use-select-bar-item-value.js
+++ b/src/context-selection/org-unit-selector-bar-item/use-select-bar-item-value.js
@@ -1,22 +1,27 @@
 import i18n from '@dhis2/d2-i18n'
-import useDataSetOrgUnitPaths from './use-data-set-org-unit-paths.js'
 import useOrgUnit from './use-organisation-unit.js'
 import useUserOrgUnits from './use-user-org-units.js'
 
 export default function useSelectorBarItemValue() {
     const orgUnit = useOrgUnit()
     const userOrgUnits = useUserOrgUnits()
-    const dataSetOrgUnitPaths = useDataSetOrgUnitPaths()
+    // @TODO: Figure out how to only use org units that are connected to the
+    // data set.
+    // const dataSetOrgUnitPaths = useDataSetOrgUnitPaths()
 
     if (
         userOrgUnits.loading ||
-        orgUnit.loading ||
-        dataSetOrgUnitPaths.loading
+        orgUnit.loading
+        // || dataSetOrgUnitPaths.loading
     ) {
         return i18n.t('Fetching organisation unit info')
     }
 
-    if (orgUnit.error || userOrgUnits.error || dataSetOrgUnitPaths.error) {
+    if (
+        orgUnit.error ||
+        userOrgUnits.error
+        // || dataSetOrgUnitPaths.error
+    ) {
         return i18n.t('Error occurred while loading organisation unit info')
     }
 


### PR DESCRIPTION
Currently the data set requests contains only the leaf nodes which makes the removed functionality kind of senseless.
Also we agreed to indicate org units that are connected instead of filtering out the ones that are not connected for UX reasons