### PR TITLE
refactor: only set params and id if present

### DIFF
--- a/src/app/query-client/use-query-client.js
+++ b/src/app/query-client/use-query-client.js
@@ -12,11 +12,15 @@ const useQueryClient = () => {
     const queryFn = ({ queryKey }) => {
         const [resource, options] = queryKey
         const appRuntimeQuery = {
-            [resource]: {
-                resource,
-                id: options?.id,
-                params: options?.params,
-            },
+            [resource]: { resource },
+        }
+
+        if (options?.id) {
+            appRuntimeQuery[resource].id = options.id
+        }
+
+        if (options?.params) {
+            appRuntimeQuery[resource].params = options.params
         }
 
         return engine.query(appRuntimeQuery).then((data) => data[resource])


### PR DESCRIPTION
The existing code works, but I think this approach is better as it only sets the `id` and `params` keys if there are associated values.