### PR TITLE
feat: memoize selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,10 +51,12 @@
         "lodash.throttle": "^4.1.1",
         "prop-types": "^15.7.2",
         "query-string": "^7.0.1",
+        "re-reselect": "^4.0.0",
         "react-final-form": "^6.5.7",
         "react-query": "4.0.0-alpha.10",
         "react-router-dom": "^5",
         "tabbable": "^5.2.1",
+        "reselect": "^4.1.5",
         "use-query-params": "^1.2.3"
     },
     "resolutions": {

--- a/src/custom-forms/use-custom-forms.js
+++ b/src/custom-forms/use-custom-forms.js
@@ -1,15 +1,20 @@
 import { useQuery } from 'react-query'
+import { createSelector } from 'reselect'
 import keys from './query-key-factory.js'
+
+const getDataSets = (data) => data.dataSets
+const getCustomForms = createSelector(getDataSets, (dataSets) =>
+    dataSets
+        .filter((dataSet) => dataSet.formType === 'CUSTOM')
+        .map((dataSet) => ({
+            id: dataSet.dataEntryForm.id,
+            version: dataSet.version,
+        }))
+)
 
 const useCustomForms = () => {
     return useQuery(keys.all, {
-        select: (data) =>
-            data.dataSets
-                .filter((dataSet) => dataSet.formType === 'CUSTOM')
-                .map((dataSet) => ({
-                    id: dataSet.dataEntryForm.id,
-                    version: dataSet.version,
-                })),
+        select: getCustomForms,
     })
 }
 

--- a/src/data-workspace/default-form.js
+++ b/src/data-workspace/default-form.js
@@ -5,7 +5,7 @@ import React from 'react'
 import { useMetadata } from '../metadata/index.js'
 import {
     getDataElementsByDataSetId,
-    groupDataElementsByCatCombo,
+    getGroupedDataElementsByCatCombo,
 } from '../metadata/selectors.js'
 import { CategoryComboTable } from './category-combo-table.js'
 import styles from './entry-form.module.css'
@@ -18,7 +18,10 @@ export const DefaultForm = ({ dataSet, globalFilterText }) => {
     }
 
     const dataElements = getDataElementsByDataSetId(data, dataSet.id)
-    const groupedDataElements = groupDataElementsByCatCombo(data, dataElements)
+    const groupedDataElements = getGroupedDataElementsByCatCombo(
+        data,
+        dataElements
+    )
 
     return (
         <section className="wrapper">

--- a/src/data-workspace/section-form/section.js
+++ b/src/data-workspace/section-form/section.js
@@ -12,8 +12,8 @@ import React, { useState } from 'react'
 import { useMetadata } from '../../metadata/index.js'
 import {
     getDataElementsBySection,
-    groupDataElementsByCatCombo,
-    groupDataElementsByCatComboInOrder,
+    getGroupedDataElementsByCatCombo,
+    getGroupedDataElementsByCatComboInOrder,
 } from '../../metadata/selectors.js'
 import { CategoryComboTable } from '../category-combo-table.js'
 import styles from './section.module.css'
@@ -33,8 +33,8 @@ export const SectionFormSection = ({ section, globalFilterText }) => {
         section.id
     )
     const groupedDataElements = section.disableDataElementAutoGroup
-        ? groupDataElementsByCatComboInOrder(data, dataElements)
-        : groupDataElementsByCatCombo(data, dataElements)
+        ? getGroupedDataElementsByCatComboInOrder(data, dataElements)
+        : getGroupedDataElementsByCatCombo(data, dataElements)
 
     const maxColumnsInSection = Math.max(
         ...groupedDataElements.map(

--- a/src/metadata/selectors.test.js
+++ b/src/metadata/selectors.test.js
@@ -15,8 +15,8 @@ import {
     getDataSetById,
     getDataSets,
     getSections,
-    groupDataElementsByCatCombo,
-    groupDataElementsByCatComboInOrder,
+    getGroupedDataElementsByCatCombo,
+    getGroupedDataElementsByCatComboInOrder,
 } from './selectors.js'
 
 describe('simple selectors', () => {
@@ -343,7 +343,7 @@ describe('complex selectors that select by id', () => {
 })
 
 describe('selectors that group dataElements', () => {
-    describe('groupDataElementsByCatComboInOrder', () => {
+    describe('getGroupedDataElementsByCatComboInOrder', () => {
         it('returns the expected data', () => {
             const categoryComboOne = { id: 'one' }
             const categoryComboTwo = { id: 'two' }
@@ -374,12 +374,12 @@ describe('selectors that group dataElements', () => {
             ]
 
             expect(
-                groupDataElementsByCatComboInOrder(data, dataElements)
+                getGroupedDataElementsByCatComboInOrder(data, dataElements)
             ).toEqual(expected)
         })
     })
 
-    describe('groupDataElementsByCatCombo', () => {
+    describe('getGroupedDataElementsByCatCombo', () => {
         it('returns the expected data', () => {
             const categoryComboOne = { id: 'one' }
             const categoryComboTwo = { id: 'two' }
@@ -405,9 +405,9 @@ describe('selectors that group dataElements', () => {
                 },
             ]
 
-            expect(groupDataElementsByCatCombo(data, dataElements)).toEqual(
-                expected
-            )
+            expect(
+                getGroupedDataElementsByCatCombo(data, dataElements)
+            ).toEqual(expected)
         })
     })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -13677,6 +13677,11 @@ rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+re-reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/re-reselect/-/re-reselect-4.0.0.tgz#9ddec4c72c4d952f68caa5aa4b76a9ed38b75cac"
+  integrity sha512-wuygyq8TXUlSdVXv2kigXxQNOgdb9m7LbIjwfTNGSpaY1riLd5e+VeQjlQMyUtrk0oiyhi1AqIVynworl3qxHA==
+
 react-app-polyfill@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-2.0.0.tgz#a0bea50f078b8a082970a9d853dc34b6dcc6a3cf"
@@ -14196,6 +14201,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
+  integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==
 
 resize-observer-polyfill@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
This adds memoization to our selectors in a manner that's easy to use with react-query's select, and shares its cache globally. So computations will only run once across the entire app as long as input stays the same. End goal being easy integration of memoization with our data fetching hooks.

Since reselect has a cache size of 1 it won't work with selectors that take parameters like an id. Usage with an id will invalidate the cache for other ids. So I'm using a small wrapper called re-reselect to create a reselect cache per id. Reselect and re-reselect are small. Will add just 2 to 3 kb to the bundle when minified, in total.

I've checked the memoization and currently it breaks only here: https://github.com/dhis2/data-entry-app/blob/development/src/data-workspace/category-combo-table.js#L84. Which is because a new array is created there every render, so that's expected behaviour. I can fix that after this branch.

I think it's probably best to rebase this on @Birk's work here: https://github.com/dhis2/data-entry-app/pull/46. Or I can help with rebasing that branch on this. We can see what's the easiest. I've kept all fn signatures intact, so it should be an easy rebase.

- ~~Renamed get -> select~~
- ~~Removed unused exports~~
- Removed unused selectors (see below)
- Added jsdoc param docs for all selectors without clear params
- Grouped metadata selectors to make file easier to scan (to my eyes at least, hope that generalizes to everyone)

Removed (unused) selectors:

- getDataElementById
- getSectionsByDataSetId
- getCategoryCombosByDataElements
- getCategoryCombosByDataSetId
- getCategoryOptionById
- getCategoryOptionsByCoCId
- getCategoryOptionComboById
- getSortedCategoryOptionCombosByCategoryComboId