### PR TITLE
fix(data-value-mutations): allow mutation control

### DIFF
--- a/src/data-workspace/inputs/boolean-radios.js
+++ b/src/data-workspace/inputs/boolean-radios.js
@@ -3,8 +3,8 @@ import { Button, Radio } from '@dhis2/ui'
 import cx from 'classnames'
 import React, { useState } from 'react'
 import { useField, useForm } from 'react-final-form'
-import { useDataValueMutation } from '../data-entry-cell/use-data-value-mutation.js'
 import styles from './inputs.module.css'
+import useDataValueMutation from './use-data-value-mutation.js'
 import { convertCallbackSignatures, InputPropTypes } from './utils.js'
 
 // ? Will this fail to reflect a value on the server if it's not exactly `true` or `false`?
@@ -113,4 +113,5 @@ export const BooleanRadios = ({
         </div>
     )
 }
+
 BooleanRadios.propTypes = InputPropTypes

--- a/src/data-workspace/inputs/file-inputs.js
+++ b/src/data-workspace/inputs/file-inputs.js
@@ -4,11 +4,9 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { useField } from 'react-final-form'
 import { useQuery } from 'react-query'
-import {
-    MUTATION_TYPES,
-    useDataValueMutation,
-} from '../data-entry-cell/use-data-value-mutation.js'
 import styles from './inputs.module.css'
+import useDeleteValueMutation from './use-delete-value-mutation.js'
+import useUploadFileMutation from './use-upload-file-mutation.js'
 
 const formatFileSize = (size) => {
     return `${(size / 1024).toFixed(2)} KB`
@@ -44,10 +42,8 @@ export const FileResourceInput = ({
                 typeof input.value === 'string',
         }
     )
-    const { mutate: uploadFile } = useDataValueMutation(
-        MUTATION_TYPES.FILE_UPLOAD
-    )
-    const { mutate: deleteFile } = useDataValueMutation(MUTATION_TYPES.DELETE)
+    const { mutate: uploadFile } = useUploadFileMutation()
+    const { mutate: deleteFile } = useDeleteValueMutation()
 
     const handleChange = ({ files }) => {
         const newFile = files[0]

--- a/src/data-workspace/inputs/generic-input.js
+++ b/src/data-workspace/inputs/generic-input.js
@@ -8,9 +8,9 @@ import {
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import { useField } from 'react-final-form'
-import { useDataValueMutation } from '../data-entry-cell/use-data-value-mutation.js'
 import { VALUE_TYPES } from '../data-entry-cell/value-types.js'
 import styles from './inputs.module.css'
+import useDataValueMutation from './use-data-value-mutation.js'
 import { InputPropTypes } from './utils.js'
 import {
     // date,

--- a/src/data-workspace/inputs/long-text.js
+++ b/src/data-workspace/inputs/long-text.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { useField } from 'react-final-form'
-import { useDataValueMutation } from '../data-entry-cell/use-data-value-mutation.js'
 import styles from './inputs.module.css'
+import useDataValueMutation from './use-data-value-mutation.js'
 import { InputPropTypes } from './utils.js'
 
 export const LongText = ({ fieldname, dataValueParams, setSyncStatus }) => {

--- a/src/data-workspace/inputs/option-set.js
+++ b/src/data-workspace/inputs/option-set.js
@@ -5,8 +5,8 @@ import React, { useState } from 'react'
 import { useField } from 'react-final-form'
 import { useMetadata } from '../../metadata/index.js'
 import { getOptionSetById } from '../../metadata/selectors.js'
-import { useDataValueMutation } from '../data-entry-cell/use-data-value-mutation.js'
 import styles from './inputs.module.css'
+import useDataValueMutation from './use-data-value-mutation.js'
 import { InputPropTypes } from './utils.js'
 
 export const OptionSet = ({

--- a/src/data-workspace/inputs/pure-data-value-helpers.js
+++ b/src/data-workspace/inputs/pure-data-value-helpers.js
@@ -1,0 +1,38 @@
+// Updates dataValue without mutating previousDataValueSet
+export const updateDataValue = (
+    previousDataValueSet,
+    updatedDataValue,
+    targetIndex
+) => {
+    const newDataValues = [...previousDataValueSet.dataValues]
+    newDataValues[targetIndex] = updatedDataValue
+
+    return {
+        ...previousDataValueSet,
+        dataValues: newDataValues,
+    }
+}
+
+// Adds dataValue without mutating previousDataValueSet
+export const addDataValue = (previousDataValueSet, newDataValue) => {
+    return {
+        ...previousDataValueSet,
+        // dataValueSet.dataValues can be undefined
+        dataValues: previousDataValueSet.dataValues
+            ? [...previousDataValueSet.dataValues, newDataValue]
+            : [newDataValue],
+    }
+}
+
+// Delete dataValue without mutating previousDataValueSet
+export const deleteDataValue = (previousDataValueSet, matchIndex) => {
+    const previousDataValues = previousDataValueSet.dataValues
+    const newDataValues = [
+        ...previousDataValues.slice(0, matchIndex),
+        ...previousDataValues.slice(matchIndex + 1),
+    ]
+    return {
+        ...previousDataValueSet,
+        dataValues: newDataValues,
+    }
+}

--- a/src/data-workspace/inputs/true-only-checkbox.js
+++ b/src/data-workspace/inputs/true-only-checkbox.js
@@ -1,8 +1,8 @@
 import { Checkbox } from '@dhis2/ui'
 import React, { useState } from 'react'
 import { useField } from 'react-final-form'
-import { useDataValueMutation } from '../data-entry-cell/use-data-value-mutation.js'
 import styles from './inputs.module.css'
+import useDataValueMutation from './use-data-value-mutation.js'
 import { convertCallbackSignatures, InputPropTypes } from './utils.js'
 
 export const TrueOnlyCheckbox = ({

--- a/src/data-workspace/inputs/use-data-value-mutation.js
+++ b/src/data-workspace/inputs/use-data-value-mutation.js
@@ -5,7 +5,7 @@ import { dataValueSets } from '../query-key-factory.js'
 import { useAttributeOptionCombo } from '../use-attribute-option-combo.js'
 import { updateDataValue, addDataValue } from './pure-data-value-helpers.js'
 
-export const useDataValueMutation = () => {
+const useDataValueMutation = () => {
     const queryClient = useQueryClient()
     const [{ dataSetId, orgUnitId, periodId }] = useContextSelection()
     const attributeOptionCombo = useAttributeOptionCombo()
@@ -98,3 +98,5 @@ export const useDataValueMutation = () => {
         retry: 1,
     })
 }
+
+export default useDataValueMutation

--- a/src/data-workspace/inputs/use-data-value-mutation.js
+++ b/src/data-workspace/inputs/use-data-value-mutation.js
@@ -1,0 +1,100 @@
+import { useDataEngine } from '@dhis2/app-runtime'
+import { useQueryClient, useMutation } from 'react-query'
+import { useContextSelection } from '../../context-selection/index.js'
+import { dataValueSets } from '../query-key-factory.js'
+import { useAttributeOptionCombo } from '../use-attribute-option-combo.js'
+import { updateDataValue, addDataValue } from './pure-data-value-helpers.js'
+
+export const useDataValueMutation = () => {
+    const queryClient = useQueryClient()
+    const [{ dataSetId, orgUnitId, periodId }] = useContextSelection()
+    const attributeOptionCombo = useAttributeOptionCombo()
+    const engine = useDataEngine()
+    const mutationFn = (variables) =>
+        engine.mutate(
+            {
+                resource: 'dataValues',
+                type: 'create',
+                data: (data) => data,
+            },
+            { variables }
+        )
+
+    const dataValueSetQueryKey = dataValueSets.byIds({
+        dataSetId,
+        periodId,
+        orgUnitId,
+        attributeOptionCombo,
+    })
+
+    return useMutation(mutationFn, {
+        // Used to identify whether this mutation is running
+        mutationKey: dataValueSetQueryKey,
+        // Optimistic update of the react-query cache
+        onMutate: async (newDataValue) => {
+            // Cancel any outgoing refetches (so they don't overwrite our optimistic update)
+            await queryClient.cancelQueries(dataValueSetQueryKey)
+
+            // Snapshot the previous value
+            const previousDataValueSet =
+                queryClient.getQueryData(dataValueSetQueryKey)
+
+            // Optimistically update to the new value
+            queryClient.setQueryData(dataValueSetQueryKey, () => {
+                // dataValueSet.dataValues can be undefined
+                const previousDataValues = previousDataValueSet.dataValues || []
+                const matchIndex = previousDataValues.findIndex(
+                    (dataValue) =>
+                        dataValue.categoryOptionCombo === newDataValue.co &&
+                        dataValue.dataElement === newDataValue.de &&
+                        dataValue.orgUnit === newDataValue.ou &&
+                        dataValue.period === newDataValue.pe
+                )
+
+                const isNewDataValue = matchIndex === -1
+                // If this is a file-type data value, set value to some file metadata
+                // so it's available offline. When DVSets is refetched, the value will
+                // be replaced by a UID that will be handled in the FileResourceInput components
+                const newValue = newDataValue.value
+
+                // If the field was previously empty the dataValue won't exist yet
+                if (isNewDataValue) {
+                    const formattedNewDataValue = {
+                        attributeOptionCombo,
+                        categoryOptionCombo: newDataValue.co,
+                        dataElement: newDataValue.de,
+                        orgUnit: newDataValue.ou,
+                        period: newDataValue.pe,
+                        value: newValue,
+                    }
+
+                    return addDataValue(
+                        previousDataValueSet,
+                        formattedNewDataValue
+                    )
+                } else {
+                    const formattedNewDataValue = {
+                        ...previousDataValues[matchIndex],
+                        value: newValue,
+                    }
+
+                    return updateDataValue(
+                        previousDataValueSet,
+                        formattedNewDataValue,
+                        matchIndex
+                    )
+                }
+            })
+
+            return { previousDataValueSet, dataValueSetQueryKey }
+        },
+        // If the mutation fails, use the context returned from onMutate to roll back
+        onError: (err, newDataValue, context) => {
+            queryClient.setQueryData(
+                context.dataValueSetQueryKey,
+                context.previousDataValueSet
+            )
+        },
+        retry: 1,
+    })
+}

--- a/src/data-workspace/inputs/use-delete-value-mutation.js
+++ b/src/data-workspace/inputs/use-delete-value-mutation.js
@@ -5,7 +5,7 @@ import { dataValueSets } from '../query-key-factory.js'
 import { useAttributeOptionCombo } from '../use-attribute-option-combo.js'
 import { deleteDataValue } from './pure-data-value-helpers.js'
 
-export const useDeleteValueMutation = () => {
+const useDeleteValueMutation = () => {
     const queryClient = useQueryClient()
     const [{ dataSetId, orgUnitId, periodId }] = useContextSelection()
     const attributeOptionCombo = useAttributeOptionCombo()
@@ -66,3 +66,5 @@ export const useDeleteValueMutation = () => {
         retry: 1,
     })
 }
+
+export default useDeleteValueMutation

--- a/src/data-workspace/inputs/use-delete-value-mutation.js
+++ b/src/data-workspace/inputs/use-delete-value-mutation.js
@@ -1,0 +1,68 @@
+import { useDataEngine } from '@dhis2/app-runtime'
+import { useQueryClient, useMutation } from 'react-query'
+import { useContextSelection } from '../../context-selection/index.js'
+import { dataValueSets } from '../query-key-factory.js'
+import { useAttributeOptionCombo } from '../use-attribute-option-combo.js'
+import { deleteDataValue } from './pure-data-value-helpers.js'
+
+export const useDeleteValueMutation = () => {
+    const queryClient = useQueryClient()
+    const [{ dataSetId, orgUnitId, periodId }] = useContextSelection()
+    const attributeOptionCombo = useAttributeOptionCombo()
+    const engine = useDataEngine()
+    const mutationFn = (variables) =>
+        engine.mutate(
+            {
+                resource: 'dataValues',
+                type: 'delete',
+                params: (params) => params,
+            },
+            { variables }
+        )
+
+    const dataValueSetQueryKey = dataValueSets.byIds({
+        dataSetId,
+        periodId,
+        orgUnitId,
+        attributeOptionCombo,
+    })
+
+    return useMutation(mutationFn, {
+        // Used to identify whether this mutation is running
+        mutationKey: dataValueSetQueryKey,
+        // Optimistic update of the react-query cache
+        onMutate: async (newDataValue) => {
+            // Cancel any outgoing refetches (so they don't overwrite our optimistic update)
+            await queryClient.cancelQueries(dataValueSetQueryKey)
+
+            // Snapshot the previous value
+            const previousDataValueSet =
+                queryClient.getQueryData(dataValueSetQueryKey)
+
+            // Optimistically update to the new value
+            queryClient.setQueryData(dataValueSetQueryKey, () => {
+                // dataValueSet.dataValues can be undefined
+                const previousDataValues = previousDataValueSet.dataValues || []
+                const matchIndex = previousDataValues.findIndex(
+                    (dataValue) =>
+                        dataValue.categoryOptionCombo === newDataValue.co &&
+                        dataValue.dataElement === newDataValue.de &&
+                        dataValue.orgUnit === newDataValue.ou &&
+                        dataValue.period === newDataValue.pe
+                )
+
+                return deleteDataValue(previousDataValueSet, matchIndex)
+            })
+
+            return { previousDataValueSet, dataValueSetQueryKey }
+        },
+        // If the mutation fails, use the context returned from onMutate to roll back
+        onError: (err, newDataValue, context) => {
+            queryClient.setQueryData(
+                context.dataValueSetQueryKey,
+                context.previousDataValueSet
+            )
+        },
+        retry: 1,
+    })
+}

--- a/src/data-workspace/inputs/use-upload-file-mutation.js
+++ b/src/data-workspace/inputs/use-upload-file-mutation.js
@@ -5,7 +5,7 @@ import { dataValueSets } from '../query-key-factory.js'
 import { useAttributeOptionCombo } from '../use-attribute-option-combo.js'
 import { updateDataValue, addDataValue } from './pure-data-value-helpers.js'
 
-export const useUploadFileMutation = () => {
+const useUploadFileMutation = () => {
     const queryClient = useQueryClient()
     const [{ dataSetId, orgUnitId, periodId }] = useContextSelection()
     const attributeOptionCombo = useAttributeOptionCombo()
@@ -101,3 +101,5 @@ export const useUploadFileMutation = () => {
         retry: 1,
     })
 }
+
+export default useUploadFileMutation


### PR DESCRIPTION
Allow control over when a mutation can be considered successful. So that we don't drop any mutations that should be retried.