### PR TITLE
feat: greyed fields

### DIFF
--- a/src/data-workspace/category-combo-table/category-combo-table.js
+++ b/src/data-workspace/category-combo-table/category-combo-table.js
@@ -16,6 +16,7 @@ import {
     DataEntryField,
     useActiveCell,
 } from '../data-entry-cell/index.js'
+import { getFieldId } from '../get-field-id.js'
 import styles from './category-combo-table.module.css'
 import { TotalHeader, ColumnTotals, RowTotal } from './total-cells.js'
 
@@ -24,6 +25,7 @@ export const CategoryComboTable = ({
     dataElements,
     filterText,
     globalFilterText,
+    greyedFields,
     maxColumnsInSection,
     renderRowTotals,
     renderColumnTotals,
@@ -119,6 +121,14 @@ export const CategoryComboTable = ({
         return isThisTableActive && idxDiff < headerColSpan && idxDiff >= 0
     }
 
+    const isFieldGreyed = (de, coc) => {
+        if (!greyedFields) {
+            return false
+        }
+        const key = getFieldId(de, coc)
+        return greyedFields[key] || false
+    }
+
     return (
         <TableBody>
             {rowToColumnsMap.map((colInfo, colInfoIndex) => {
@@ -174,6 +184,7 @@ export const CategoryComboTable = ({
                                 <DataEntryField
                                     dataElement={de}
                                     categoryOptionCombo={coc}
+                                    disabled={isFieldGreyed(de, coc)}
                                 />
                             </DataEntryCell>
                         ))}
@@ -233,6 +244,8 @@ CategoryComboTable.propTypes = {
     ),
     filterText: PropTypes.string,
     globalFilterText: PropTypes.string,
+    /** Greyed fields is an object-map where [deId.cocId]: true if that field is greyed/disabled */
+    greyedFields: PropTypes.object,
     maxColumnsInSection: PropTypes.number,
     renderColumnTotals: PropTypes.bool,
     renderRowTotals: PropTypes.bool,

--- a/src/data-workspace/category-combo-table/category-combo-table.js
+++ b/src/data-workspace/category-combo-table/category-combo-table.js
@@ -121,7 +121,7 @@ export const CategoryComboTable = ({
         return isThisTableActive && idxDiff < headerColSpan && idxDiff >= 0
     }
 
-    const isFieldGreyed = (de, coc) => {
+    const isGreyedField = (de, coc) => {
         if (!greyedFields) {
             return false
         }
@@ -184,7 +184,7 @@ export const CategoryComboTable = ({
                                 <DataEntryField
                                     dataElement={de}
                                     categoryOptionCombo={coc}
-                                    disabled={isFieldGreyed(de, coc)}
+                                    disabled={isGreyedField(de, coc)}
                                 />
                             </DataEntryCell>
                         ))}

--- a/src/data-workspace/category-combo-table/category-combo-table.js
+++ b/src/data-workspace/category-combo-table/category-combo-table.js
@@ -121,14 +121,6 @@ export const CategoryComboTable = ({
         return isThisTableActive && idxDiff < headerColSpan && idxDiff >= 0
     }
 
-    const isGreyedField = (de, coc) => {
-        if (!greyedFields) {
-            return false
-        }
-        const key = getFieldId(de, coc)
-        return greyedFields[key] || false
-    }
-
     return (
         <TableBody>
             {rowToColumnsMap.map((colInfo, colInfoIndex) => {
@@ -184,7 +176,9 @@ export const CategoryComboTable = ({
                                 <DataEntryField
                                     dataElement={de}
                                     categoryOptionCombo={coc}
-                                    disabled={isGreyedField(de, coc)}
+                                    disabled={greyedFields?.has(
+                                        getFieldId(de.id, coc.id)
+                                    )}
                                 />
                             </DataEntryCell>
                         ))}
@@ -244,8 +238,8 @@ CategoryComboTable.propTypes = {
     ),
     filterText: PropTypes.string,
     globalFilterText: PropTypes.string,
-    /** Greyed fields is an object-map where [deId.cocId]: true if that field is greyed/disabled */
-    greyedFields: PropTypes.object,
+    /** Greyed fields is a Set where .has(fieldId) is true if that field is greyed/disabled */
+    greyedFields: PropTypes.instanceOf(Set),
     maxColumnsInSection: PropTypes.number,
     renderColumnTotals: PropTypes.bool,
     renderRowTotals: PropTypes.bool,

--- a/src/data-workspace/data-entry-cell/data-entry-field.js
+++ b/src/data-workspace/data-entry-cell/data-entry-field.js
@@ -7,6 +7,7 @@ import { ValidationTooltip } from './validation-tooltip.js'
 export const DataEntryField = React.memo(function DataEntryField({
     dataElement: de,
     categoryOptionCombo: coc,
+    disabled,
 }) {
     // This field name results in this structure for the form data object:
     // { [deId]: { [cocId]: value } }
@@ -21,12 +22,17 @@ export const DataEntryField = React.memo(function DataEntryField({
 
     return (
         <ValidationTooltip fieldname={fieldname}>
-            <InnerWrapper fieldname={fieldname} syncStatus={syncStatus}>
+            <InnerWrapper
+                fieldname={fieldname}
+                syncStatus={syncStatus}
+                disabled={disabled}
+            >
                 <EntryFieldInput
                     fieldname={fieldname}
                     dataElement={de}
                     categoryOptionCombo={coc}
                     setSyncStatus={setSyncStatus}
+                    disabled={disabled}
                 />
             </InnerWrapper>
         </ValidationTooltip>
@@ -40,4 +46,5 @@ DataEntryField.propTypes = {
         id: PropTypes.string.isRequired,
         valueType: PropTypes.string,
     }).isRequired,
+    disabled: PropTypes.bool,
 }

--- a/src/data-workspace/data-entry-cell/data-entry-field.js
+++ b/src/data-workspace/data-entry-cell/data-entry-field.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
+import { getFieldId } from '../get-field-id.js'
 import { EntryFieldInput } from './entry-field-input.js'
 import { InnerWrapper } from './inner-wrapper.js'
 import { ValidationTooltip } from './validation-tooltip.js'
@@ -11,7 +12,7 @@ export const DataEntryField = React.memo(function DataEntryField({
 }) {
     // This field name results in this structure for the form data object:
     // { [deId]: { [cocId]: value } }
-    const fieldname = `${de.id}.${coc.id}`
+    const fieldname = getFieldId(de, coc)
     const [syncStatus, setSyncStatus] = useState({
         syncing: false,
         synced: false,

--- a/src/data-workspace/data-entry-cell/data-entry-field.js
+++ b/src/data-workspace/data-entry-cell/data-entry-field.js
@@ -12,7 +12,7 @@ export const DataEntryField = React.memo(function DataEntryField({
 }) {
     // This field name results in this structure for the form data object:
     // { [deId]: { [cocId]: value } }
-    const fieldname = getFieldId(de, coc)
+    const fieldname = getFieldId(de.id, coc.id)
     const [syncStatus, setSyncStatus] = useState({
         syncing: false,
         synced: false,

--- a/src/data-workspace/data-entry-cell/entry-field-input.js
+++ b/src/data-workspace/data-entry-cell/entry-field-input.js
@@ -82,6 +82,7 @@ export function EntryFieldInput({
     dataElement: de,
     categoryOptionCombo: coc,
     setSyncStatus,
+    disabled,
 }) {
     const currentItemContext = useCurrentItemContext()
     const rightHandPanel = useRightHandPanelContext()
@@ -118,6 +119,7 @@ export function EntryFieldInput({
     const sharedProps = {
         fieldname,
         dataValueParams,
+        disabled,
         setSyncStatus,
         onFocus,
         onKeyDown,
@@ -138,6 +140,7 @@ EntryFieldInput.propTypes = {
         optionSetValue: PropTypes.bool,
         valueType: PropTypes.string,
     }),
+    disabled: PropTypes.bool,
     fieldname: PropTypes.string,
     setSyncStatus: PropTypes.func,
 }

--- a/src/data-workspace/data-entry-cell/inner-wrapper.js
+++ b/src/data-workspace/data-entry-cell/inner-wrapper.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { useField } from 'react-final-form'
 import { useIsMutating } from 'react-query'
-import { getFieldIdComponents } from '../get-field-id.js'
+import { parseFieldId } from '../get-field-id.js'
 import styles from './data-entry-cell.module.css'
 
 /** Three dots or triangle in top-right corner of cell */
@@ -40,7 +40,7 @@ CommentIndicator.propTypes = { isComment: PropTypes.bool }
  */
 export function InnerWrapper({ children, disabled, fieldname, syncStatus }) {
     const { dataElementId: deId, categoryOptionComboId: cocId } =
-        getFieldIdComponents(fieldname)
+        parseFieldId(fieldname)
     const {
         meta: { active, invalid },
     } = useField(fieldname, { subscription: { active: true, invalid: true } })

--- a/src/data-workspace/data-entry-cell/inner-wrapper.js
+++ b/src/data-workspace/data-entry-cell/inner-wrapper.js
@@ -37,7 +37,7 @@ CommentIndicator.propTypes = { isComment: PropTypes.bool }
  * This inner wrapper provides styles and layout for the entry field based on
  * its various states
  */
-export function InnerWrapper({ children, fieldname, syncStatus }) {
+export function InnerWrapper({ children, disabled, fieldname, syncStatus }) {
     const [deId, cocId] = fieldname.split('.')
     const {
         meta: { active, invalid },
@@ -61,7 +61,7 @@ export function InnerWrapper({ children, fieldname, syncStatus }) {
         <div
             className={cx(styles.cellInnerWrapper, cellStateClassName, {
                 [styles.active]: active,
-                [styles.disabled]: false, // todo
+                [styles.disabled]: disabled,
             })}
         >
             {children}
@@ -76,6 +76,7 @@ export function InnerWrapper({ children, fieldname, syncStatus }) {
 }
 InnerWrapper.propTypes = {
     children: PropTypes.node,
+    disabled: PropTypes.bool,
     fieldname: PropTypes.string,
     syncStatus: PropTypes.shape({
         synced: PropTypes.bool,

--- a/src/data-workspace/data-entry-cell/inner-wrapper.js
+++ b/src/data-workspace/data-entry-cell/inner-wrapper.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { useField } from 'react-final-form'
 import { useIsMutating } from 'react-query'
+import { getFieldIdComponents } from '../get-field-id.js'
 import styles from './data-entry-cell.module.css'
 
 /** Three dots or triangle in top-right corner of cell */
@@ -38,7 +39,8 @@ CommentIndicator.propTypes = { isComment: PropTypes.bool }
  * its various states
  */
 export function InnerWrapper({ children, disabled, fieldname, syncStatus }) {
-    const [deId, cocId] = fieldname.split('.')
+    const { dataElementId: deId, categoryOptionComboId: cocId } =
+        getFieldIdComponents(fieldname)
     const {
         meta: { active, invalid },
     } = useField(fieldname, { subscription: { active: true, invalid: true } })

--- a/src/data-workspace/data-entry-cell/use-active-cell.js
+++ b/src/data-workspace/data-entry-cell/use-active-cell.js
@@ -1,10 +1,11 @@
 import { useFormState } from 'react-final-form'
+import { getFieldIdComponents } from '../get-field-id.js'
 
 export const useActiveCell = () => {
     const { active } = useFormState({ subscription: { active: true } })
 
-    const [deId, cocId] = active ? active.split('.') : [null, null]
-
+    const { dataElementId: deId, categoryOptionComboId: cocId } =
+        getFieldIdComponents(active)
     // Optional category option IDs (requires useMetadata hook):
     // const coIds = active
     //     ? getCategoryOptionComboById(metadata, cocId).categoryOptions

--- a/src/data-workspace/data-entry-cell/use-active-cell.js
+++ b/src/data-workspace/data-entry-cell/use-active-cell.js
@@ -1,11 +1,11 @@
 import { useFormState } from 'react-final-form'
-import { getFieldIdComponents } from '../get-field-id.js'
+import { parseFieldId } from '../get-field-id.js'
 
 export const useActiveCell = () => {
     const { active } = useFormState({ subscription: { active: true } })
 
     const { dataElementId: deId, categoryOptionComboId: cocId } =
-        getFieldIdComponents(active)
+        parseFieldId(active)
     // Optional category option IDs (requires useMetadata hook):
     // const coIds = active
     //     ? getCategoryOptionComboById(metadata, cocId).categoryOptions

--- a/src/data-workspace/get-field-id.js
+++ b/src/data-workspace/get-field-id.js
@@ -1,8 +1,8 @@
-export const getFieldId = (de, coc) => {
-    return `${de.id}.${coc.id}`
+export const getFieldId = (dataElementId, categoryOptionComboId) => {
+    return `${dataElementId}.${categoryOptionComboId}`
 }
 
-export const getFieldIdComponents = (fieldId) => {
+export const parseFieldId = (fieldId) => {
     if (!fieldId) {
         return {
             dataElementId: null,

--- a/src/data-workspace/get-field-id.js
+++ b/src/data-workspace/get-field-id.js
@@ -3,10 +3,17 @@ export const getFieldId = (de, coc) => {
 }
 
 export const getFieldIdComponents = (fieldId) => {
-    const [dataElement, categoryOptionCombo] = fieldId.split('.')
+    if (!fieldId) {
+        return {
+            dataElementId: null,
+            categoryOptionComboId: null,
+        }
+    }
+
+    const [dataElementId, categoryOptionComboId] = fieldId.split('.')
 
     return {
-        dataElement,
-        categoryOptionCombo,
+        dataElementId,
+        categoryOptionComboId,
     }
 }

--- a/src/data-workspace/get-field-id.js
+++ b/src/data-workspace/get-field-id.js
@@ -1,0 +1,12 @@
+export const getFieldId = (de, coc) => {
+    return `${de.id}.${coc.id}`
+}
+
+export const getFieldIdComponents = (fieldId) => {
+    const [dataElement, categoryOptionCombo] = fieldId.split('.')
+
+    return {
+        dataElement,
+        categoryOptionCombo,
+    }
+}

--- a/src/data-workspace/inputs/boolean-radios.js
+++ b/src/data-workspace/inputs/boolean-radios.js
@@ -16,6 +16,7 @@ import { convertCallbackSignatures, InputPropTypes } from './utils.js'
 export const BooleanRadios = ({
     fieldname,
     dataValueParams,
+    disabled,
     setSyncStatus,
     onKeyDown,
     onFocus,
@@ -95,6 +96,7 @@ export const BooleanRadios = ({
                     yesField.input.onBlur(e)
                 }}
                 onKeyDown={onKeyDown}
+                disabled={disabled}
             />
             <Radio
                 dense
@@ -106,6 +108,7 @@ export const BooleanRadios = ({
                     noField.input.onBlur(e)
                 }}
                 onKeyDown={onKeyDown}
+                disabled={disabled}
             />
             <Button
                 small
@@ -127,6 +130,7 @@ export const BooleanRadios = ({
                     clearField.input.onBlur()
                 }}
                 onKeyDown={onKeyDown}
+                disabled={disabled}
             >
                 {i18n.t('Clear')}
             </Button>

--- a/src/data-workspace/inputs/file-inputs.js
+++ b/src/data-workspace/inputs/file-inputs.js
@@ -18,6 +18,7 @@ export const FileResourceInput = ({
     fieldname,
     image,
     dataValueParams,
+    disabled,
     setSyncStatus,
     onKeyDown,
     onFocus,
@@ -113,6 +114,7 @@ export const FileResourceInput = ({
                         }}
                         onBlur={input.onBlur}
                         onKeyDown={onKeyDown}
+                        disabled={disabled}
                     >
                         {i18n.t('Delete')}
                     </Button>
@@ -134,6 +136,7 @@ export const FileResourceInput = ({
                             ? i18n.t('Upload an image')
                             : i18n.t('Upload a file')
                     }
+                    disabled={disabled}
                 />
             )}
         </div>
@@ -142,6 +145,7 @@ export const FileResourceInput = ({
 
 FileResourceInput.propTypes = {
     dataValueParams: PropTypes.objectOf(PropTypes.string),
+    disabled: PropTypes.bool,
     fieldname: PropTypes.string,
     image: PropTypes.bool,
     setSyncStatus: PropTypes.func,

--- a/src/data-workspace/inputs/generic-input.js
+++ b/src/data-workspace/inputs/generic-input.js
@@ -59,6 +59,7 @@ export const GenericInput = ({
     valueType,
     onKeyDown,
     onFocus,
+    disabled,
 }) => {
     const [lastSyncedValue, setLastSyncedValue] = useState()
     const { mutate } = useDataValueMutation()
@@ -103,6 +104,7 @@ export const GenericInput = ({
                 input.onBlur(e)
             }}
             onKeyDown={onKeyDown}
+            disabled={disabled}
         />
     )
 }

--- a/src/data-workspace/inputs/long-text.js
+++ b/src/data-workspace/inputs/long-text.js
@@ -10,6 +10,7 @@ export const LongText = ({
     setSyncStatus,
     onKeyDown,
     onFocus,
+    disabled,
 }) => {
     const { input, meta } = useField(fieldname, {
         subscription: { value: true, dirty: true, valid: true },
@@ -53,6 +54,7 @@ export const LongText = ({
                 input.onBlur(e)
             }}
             onKeyDown={onKeyDown}
+            disabled={disabled}
         />
     )
 }

--- a/src/data-workspace/inputs/option-set.js
+++ b/src/data-workspace/inputs/option-set.js
@@ -15,6 +15,7 @@ export const OptionSet = ({
     setSyncStatus,
     onKeyDown,
     onFocus,
+    disabled,
 }) => {
     const { input } = useField(fieldname, { subscription: { value: true } })
     const { data: metadata } = useMetadata()
@@ -69,6 +70,7 @@ export const OptionSet = ({
                     }}
                     onKeyDown={onKeyDown}
                     onBlur={() => input.onBlur()}
+                    disabled={disabled}
                 >
                     {options.map(({ name }) => (
                         <SingleSelectOption
@@ -90,6 +92,7 @@ export const OptionSet = ({
                         handleChange('')
                         input.onBlur()
                     }}
+                    disabled={disabled}
                 >
                     {i18n.t('Clear')}
                 </Button>

--- a/src/data-workspace/inputs/true-only-checkbox.js
+++ b/src/data-workspace/inputs/true-only-checkbox.js
@@ -11,6 +11,7 @@ export const TrueOnlyCheckbox = ({
     setSyncStatus,
     onKeyDown,
     onFocus,
+    disabled,
 }) => {
     const { input, meta } = useField(fieldname, {
         type: 'checkbox',
@@ -57,6 +58,7 @@ export const TrueOnlyCheckbox = ({
                     input.onBlur(e)
                 }}
                 onKeyDown={onKeyDown}
+                disabled={disabled}
             />
         </div>
     )

--- a/src/data-workspace/inputs/utils.js
+++ b/src/data-workspace/inputs/utils.js
@@ -13,6 +13,7 @@ export const convertCallbackSignatures = (props) => ({
 export const InputPropTypes = {
     onKeyDown: PropTypes.func.isRequired,
     dataValueParams: PropTypes.objectOf(PropTypes.string),
+    disabled: PropTypes.bool,
     lastSyncedValue: PropTypes.any,
     setSyncStatus: PropTypes.func,
     onFocus: PropTypes.func,

--- a/src/data-workspace/section-form/section.js
+++ b/src/data-workspace/section-form/section.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import { useMetadata, selectors } from '../../metadata/index.js'
 import { CategoryComboTable } from '../category-combo-table/index.js'
+import { getFieldId } from '../get-field-id.js'
 import styles from './section.module.css'
 
 export const SectionFormSection = ({
@@ -40,8 +41,17 @@ export const SectionFormSection = ({
             (grp) => grp.categoryCombo.categoryOptionCombos?.length || 1
         )
     )
-    const filterInputId = `filter-input-${section.id}`
 
+    const greyedFieldsMap = section.greyedFields.reduce((acc, greyedField) => {
+        const key = getFieldId(
+            greyedField.dataElement,
+            greyedField.categoryOptionCombo
+        )
+        acc[key] = true
+        return acc
+    }, {})
+
+    const filterInputId = `filter-input-${section.id}`
     return (
         <Table className={styles.table} suppressZebraStriping>
             <TableHead>
@@ -94,6 +104,7 @@ export const SectionFormSection = ({
                     maxColumnsInSection={maxColumnsInSection}
                     renderRowTotals={section.showRowTotals}
                     renderColumnTotals={section.showColumnTotals}
+                    greyedFields={greyedFieldsMap}
                 />
             ))}
         </Table>
@@ -110,6 +121,7 @@ SectionFormSection.propTypes = {
         description: PropTypes.string,
         disableDataElementAutoGroup: PropTypes.bool,
         displayName: PropTypes.string,
+        greyedFields: PropTypes.array,
         id: PropTypes.string,
         showColumnTotals: PropTypes.bool,
         showRowTotals: PropTypes.bool,

--- a/src/data-workspace/section-form/section.js
+++ b/src/data-workspace/section-form/section.js
@@ -42,14 +42,14 @@ export const SectionFormSection = ({
         )
     )
 
-    const greyedFieldsMap = section.greyedFields.reduce((acc, greyedField) => {
-        const key = getFieldId(
-            greyedField.dataElement,
-            greyedField.categoryOptionCombo
+    const greyedFields = new Set(
+        section.greyedFields.map((greyedField) =>
+            getFieldId(
+                greyedField.dataElement.id,
+                greyedField.categoryOptionCombo.id
+            )
         )
-        acc[key] = true
-        return acc
-    }, {})
+    )
 
     const filterInputId = `filter-input-${section.id}`
     return (
@@ -104,7 +104,7 @@ export const SectionFormSection = ({
                     maxColumnsInSection={maxColumnsInSection}
                     renderRowTotals={section.showRowTotals}
                     renderColumnTotals={section.showColumnTotals}
-                    greyedFields={greyedFieldsMap}
+                    greyedFields={greyedFields}
                 />
             ))}
         </Table>


### PR DESCRIPTION
Adds support for `greyedFields`/disabled-fields. 

This can be activated for `DataSet sections` in the `Maintenance app`. Navigate to list of `Data Sets`, find a section-dataSet -> Hamburger-menu -> Manage sections -> Hamburger Menu in list of Sections -> Manage Grey Fields -> Click field to be disabled. 

Note that there's a backend bug where setting a greyField for a dataElement with `categoryComb` `None/default` results in a 500-error. See [DHIS2-13371](https://jira.dhis2.org/browse/DHIS2-13371). 