### PR TITLE
feat: add print support

### DIFF
--- a/src/app/app-wrapper.js
+++ b/src/app/app-wrapper.js
@@ -3,6 +3,7 @@ import React from 'react'
 import { QueryClientProvider } from 'react-query'
 import { HashRouter as Router, Route } from 'react-router-dom'
 import { QueryParamProvider } from 'use-query-params'
+import PrintAreaProvider from '../data-workspace/print-area/print-area-provider.js'
 import { RightHandPanelProvider } from '../right-hand-panel/index.js'
 import { CurrentItemProvider } from '../shared/index.js'
 import App from './app.js'
@@ -20,7 +21,9 @@ const AppWrapper = () => {
                     <QueryParamProvider ReactRouterRoute={Route}>
                         <CurrentItemProvider>
                             <RightHandPanelProvider>
-                                <App />
+                                <PrintAreaProvider>
+                                    <App />
+                                </PrintAreaProvider>
                             </RightHandPanelProvider>
                         </CurrentItemProvider>
                     </QueryParamProvider>

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1,3 +1,40 @@
 body {
     background: var(--colors-grey100);
 }
+
+@media print {
+    /* This style is needed otherwise Chrome is printing only the visible part of a scrollable div, so we end up with one page of the form printed
+    https://stackoverflow.com/questions/25187715/css-print-media-query-prints-only-first-page */
+    * { overflow: visible !important; } 
+    div {
+        display: block !important; /* This is needed to get around issues with FireFox printing CSS grids: https://tosbourn.com/firefox-printing-issue-for-grid-css/ */
+        max-width: 100% !important;
+    }
+    .app-shell-adapter > header  {
+        display: none;
+    }
+
+    .hide-for-print {
+        display: none !important;
+    }
+    
+    table {
+        max-width: 100% !important;
+        page-break-after: always;
+    }
+    
+    table:last-child {
+        page-break-after: avoid;
+    }
+    
+    tr, td {
+        break-inside: avoid;
+        page-break-inside: avoid;
+    }
+
+    .form-cleared input,
+    .form-cleared textarea,
+    .form-cleared input+div svg /* we are adding an svg to style the checkbox which we need to hide as well in empty forms*/ {
+        visibility: hidden !important;
+    }
+}

--- a/src/app/layout/layout.module.css
+++ b/src/app/layout/layout.module.css
@@ -9,6 +9,16 @@
     transition: grid-template-columns 200ms ease-out;
 }
 
+@media print {
+    .wrapper :global(.controls) {
+        display: flex !important;
+        flex-direction: row;
+    }
+    .wrapper :global(.controls) :global(.clear-selections) {
+        display: none !important;
+    }
+}
+
 .wrapper.showSidebar {
     grid-template-columns: 1fr 380px;
 }

--- a/src/context-selection/context-selection/right-hand-side-content.js
+++ b/src/context-selection/context-selection/right-hand-side-content.js
@@ -1,10 +1,12 @@
+import classNames from 'classnames'
 import React from 'react'
 import { OptionsButton } from '../options/index.js'
 import styles from './right-hand-side-content.module.css'
 
 export default function RightHandSideContent() {
+    const containerStyles = classNames(styles.container, 'hide-for-print')
     return (
-        <div className={styles.container}>
+        <div className={containerStyles}>
             <OptionsButton />
         </div>
     )

--- a/src/context-selection/options/options.js
+++ b/src/context-selection/options/options.js
@@ -1,16 +1,29 @@
 import i18n from '@dhis2/d2-i18n'
 import { FlyoutMenu, MenuItem, MenuDivider, DropdownButton } from '@dhis2/ui'
 import React, { useState } from 'react'
+import { usePrintableArea } from '../../data-workspace/print-area/print-area-context.js'
 import { useRightHandPanelContext } from '../../right-hand-panel/index.js'
 
 export default function Options() {
     const rightHandPanel = useRightHandPanelContext()
+    const { printForm } = usePrintableArea()
+
     const [showMenu, setShowMenu] = useState(false)
 
+    const print = (isEmptyForm) => () => {
+        setShowMenu(false)
+        printForm(isEmptyForm)
+    }
     const optionsMenu = (
         <FlyoutMenu>
-            <MenuItem label={i18n.t('Print form with values')} disabled />
-            <MenuItem label={i18n.t('Print empty form')} disabled />
+            <MenuItem
+                onClick={print(false)}
+                label={i18n.t('Print form with values')}
+            />
+            <MenuItem
+                onClick={print(true)}
+                label={i18n.t('Print empty form')}
+            />
             <MenuDivider />
             <MenuItem
                 label={i18n.t('Help')}

--- a/src/data-workspace/custom-form/custom-form.module.css
+++ b/src/data-workspace/custom-form/custom-form.module.css
@@ -56,3 +56,13 @@ prevent accidentally applying this style to cells in the table body
     border-color: var(--colors-grey800);
     color: var(--colors-white);
 }
+
+@media print {
+    .customForm :global(table) > :global(tr:first-child) > :global(th),  
+    .customForm :global(table) > :global(tbody:first-child) > :global(tr:first-child) > :global(th),
+    .customForm :global(table) > :global(thead) > :global(tr) > :global(th) {
+        background-color: transparent !important;
+        border: 1px solid var(--colors-grey400);
+        color: black !important;
+    }
+}

--- a/src/data-workspace/data-workspace.js
+++ b/src/data-workspace/data-workspace.js
@@ -1,5 +1,6 @@
 import i18n from '@dhis2/d2-i18n'
 import { CenteredContent, CircularLoader, NoticeBox } from '@dhis2/ui'
+import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { MutationIndicator } from '../app/mutation-indicator/index.js'
@@ -51,6 +52,8 @@ export const DataWorkspace = ({ selectionHasNoFormMessage }) => {
         return 'Error!'
     }
 
+    const footerClasses = classNames(styles.footer, 'hide-for-print')
+
     return (
         <FinalFormWrapper
             dataValueSet={initialDataValuesFetch.data?.dataValues}
@@ -62,7 +65,7 @@ export const DataWorkspace = ({ selectionHasNoFormMessage }) => {
                     </div>
                 </main>
 
-                <footer className={styles.footer}>
+                <footer className={footerClasses}>
                     <div
                         // This div and its content will be removed
                         // once we can display this in the headerbar

--- a/src/data-workspace/filter-field.js
+++ b/src/data-workspace/filter-field.js
@@ -1,13 +1,15 @@
 import i18n from '@dhis2/d2-i18n'
 import { Button, InputField } from '@dhis2/ui'
+import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { FORM_TYPES } from './constants.js'
 import styles from './entry-form.module.css'
 
 export default function FilterField({ value, setFilterText, formType }) {
+    const wrapperClasses = classNames(styles.filterWrapper, 'hide-for-print')
     return (
-        <div className={styles.filterWrapper}>
+        <div className={wrapperClasses}>
             <InputField
                 name="filter-input"
                 className={styles.filterField}

--- a/src/data-workspace/print-area/print-area-context.js
+++ b/src/data-workspace/print-area/print-area-context.js
@@ -1,0 +1,15 @@
+import { useContext, createContext } from 'react'
+
+const PrintContext = createContext()
+
+export default PrintContext
+
+export function usePrintableArea() {
+    const context = useContext(PrintContext)
+    if (context === undefined) {
+        throw new Error(
+            'usePrintableArea must be used within a PrintContextProvider'
+        )
+    }
+    return context
+}

--- a/src/data-workspace/print-area/print-area-provider.js
+++ b/src/data-workspace/print-area/print-area-provider.js
@@ -1,0 +1,39 @@
+import PropTypes from 'prop-types'
+import React, { useState, useEffect } from 'react'
+import PrintAreaContext from './print-area-context.js'
+
+export default function PrintAreaProvider({ children }) {
+    const [formPrinting, setPrinting] = useState(null)
+    const [formCleared, setFormCleared] = useState(null)
+
+    useEffect(() => {
+        if (formPrinting) {
+            window.print()
+        }
+        // cleanup function, which is ran before running the effect next time, so it makes sure the state is reset
+        return () => {
+            setPrinting(false)
+            setFormCleared(false)
+        }
+    }, [formPrinting, formCleared])
+
+    const printForm = (isEmptyForm = false) => {
+        setFormCleared(isEmptyForm)
+        setPrinting(true)
+    }
+
+    const value = {
+        formPrinting,
+        printForm,
+    }
+
+    return (
+        <PrintAreaContext.Provider value={value}>
+            <div className={formCleared ? 'form-cleared' : ''}>{children}</div>
+        </PrintAreaContext.Provider>
+    )
+}
+
+PrintAreaProvider.propTypes = {
+    children: PropTypes.node.isRequired,
+}

--- a/src/data-workspace/section-form/section.js
+++ b/src/data-workspace/section-form/section.js
@@ -7,6 +7,7 @@ import {
     TableHead,
     TableRowHead,
 } from '@dhis2/ui'
+import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import { useMetadata, selectors } from '../../metadata/index.js'
@@ -52,6 +53,8 @@ export const SectionFormSection = ({
     )
 
     const filterInputId = `filter-input-${section.id}`
+    const headerCellStyles = classNames(styles.headerCell, 'hide-for-print')
+
     return (
         <Table className={styles.table} suppressZebraStriping>
             <TableHead>
@@ -71,7 +74,7 @@ export const SectionFormSection = ({
                     </TableCellHead>
                 </TableRowHead>
                 <TableRowHead>
-                    <TableCellHead colSpan="100%" className={styles.headerCell}>
+                    <TableCellHead colSpan="100%" className={headerCellStyles}>
                         <label
                             htmlFor={filterInputId}
                             className={styles.filterWrapper}

--- a/src/data-workspace/section-form/section.module.css
+++ b/src/data-workspace/section-form/section.module.css
@@ -5,6 +5,14 @@
     height: 100% !important;
 }
 
+@media print {
+    .labelWrapper {
+        background-color: transparent !important;
+    }
+    .title, .description {
+        color: black !important;
+    }
+}
 .headerCell {
     padding: 0 !important;
     height: auto !important;


### PR DESCRIPTION
Add ability to print the currently displayed data set

- [x] Add react-to-print library to allow printing only certain sections of the app
- [x] Make printing accessible from the options menu in the top bar
- [x] Support printing `section` forms
- [x] Support printing `tabbed` forms
- [x] Support printing `standard`, and `custom` forms
- [x] Allow printing empty forms

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/1014725/173795796-cb0e0bc9-6c38-4bd0-807a-85dd0ebb36d5.png">

