### PR TITLE
feat(footer): add footer UI

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-06-09T14:20:27.805Z\n"
-"PO-Revision-Date: 2022-06-09T14:20:27.805Z\n"
+"POT-Creation-Date: 2022-06-21T10:32:03.539Z\n"
+"PO-Revision-Date: 2022-06-21T10:32:03.539Z\n"
 
 msgid "Not authorized"
 msgstr "Not authorized"
@@ -23,6 +23,24 @@ msgstr "There are {{ pendingMutations }} pending mutations"
 
 msgid "Synced"
 msgstr "Synced"
+
+msgid "View details"
+msgstr "View details"
+
+msgid "Run validation"
+msgstr "Run validation"
+
+msgid "Mark incomplete"
+msgstr "Mark incomplete"
+
+msgid "Mark complete"
+msgstr "Mark complete"
+
+msgid "3 invalid values not saved"
+msgstr "3 invalid values not saved"
+
+msgid "Completed by"
+msgstr "Completed by"
 
 msgid ""
 "At least one of the categories does not have any options due to the options "

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -8,7 +8,7 @@ import {
 } from '../right-hand-panel/index.js'
 import { Layout } from './layout/index.js'
 import LoadApp from './load-app.js'
-import { MutationIndicator } from './mutation-indicator/index.js'
+// import { MutationIndicator } from './mutation-indicator/index.js'
 
 /**
  * "use-query-params" requires a router. It suggests react-router-dom in the
@@ -37,8 +37,7 @@ const App = () => {
                 main={dataWorkspace}
                 sidebar={<RightHandPanel />}
                 showSidebar={!!id}
-                footer={<MutationIndicator />}
-                showFooter
+                // footer={<MutationIndicator />}
             />
         </LoadApp>
     )

--- a/src/app/layout/layout.js
+++ b/src/app/layout/layout.js
@@ -3,7 +3,7 @@ import { node, bool } from 'prop-types'
 import React from 'react'
 import css from './layout.module.css'
 
-const Layout = ({ header, main, sidebar, footer, showSidebar, showFooter }) => {
+const Layout = ({ header, main, sidebar, showSidebar, showFooter }) => {
     const wrapperClass = classnames(css.wrapper, {
         [css.showSidebar]: showSidebar,
         [css.showFooter]: showFooter,
@@ -12,15 +12,21 @@ const Layout = ({ header, main, sidebar, footer, showSidebar, showFooter }) => {
     return (
         <div className={wrapperClass}>
             <header className={css.header}>{header}</header>
-            <main className={css.main}>{main}</main>
+
+            <div
+                // Using a div here because the data workspace component
+                // renders both a `main` and a `footer` element
+                className={css.main}
+            >
+                {main}
+            </div>
+
             <aside className={css.sidebar}>{sidebar}</aside>
-            {showFooter && <footer className={css.footer}>{footer}</footer>}
         </div>
     )
 }
 
 Layout.propTypes = {
-    footer: node,
     header: node,
     main: node,
     showFooter: bool,

--- a/src/app/layout/layout.module.css
+++ b/src/app/layout/layout.module.css
@@ -13,29 +13,16 @@
     grid-template-columns: 1fr 380px;
 }
 
-.wrapper.showFooter {
-    grid-template-areas:
-        'header header'
-        'main   sidebar'
-        'footer sidebar';
-    grid-template-rows: auto 1fr auto;
-}
-
 .header {
     grid-area: header;
 }
 
 .main {
-    overflow: auto;
+    overflow: hidden;
     grid-area: main;
-    padding: 8px;
 }
 
 .sidebar {
     grid-area: sidebar;
     overflow-y: auto;
-}
-
-.footer {
-    grid-area: footer;
 }

--- a/src/app/layout/layout.test.js
+++ b/src/app/layout/layout.test.js
@@ -29,17 +29,4 @@ describe('<Layout />', () => {
 
         expect(getByText(text)).toBeInTheDocument()
     })
-
-    it('allows toggling the footer with the showFooter prop', () => {
-        const text = 'text'
-        const { queryByText, rerender } = render(
-            <Layout footer={text} showFooter={false} />
-        )
-
-        expect(queryByText(text)).not.toBeInTheDocument()
-
-        rerender(<Layout footer={text} showFooter={true} />)
-
-        expect(queryByText(text)).toBeInTheDocument()
-    })
 })

--- a/src/bottom-bar/bottom-bar.js
+++ b/src/bottom-bar/bottom-bar.js
@@ -1,3 +1,17 @@
-const BottomBar = () => null
+import React from 'react'
+import { useCurrentItemContext } from '../shared/index.js'
+import styles from './bottom-bar.module.css'
+import DataItemBar from './data-item-bar.js'
+import MainToolBar from './main-tool-bar.js'
 
-export default BottomBar
+export default function BottomBar() {
+    const { item } = useCurrentItemContext()
+    const showDataItemBar = !!item
+
+    return (
+        <div className={styles.bottomBar}>
+            {showDataItemBar && <DataItemBar />}
+            <MainToolBar />
+        </div>
+    )
+}

--- a/src/bottom-bar/bottom-bar.module.css
+++ b/src/bottom-bar/bottom-bar.module.css
@@ -1,0 +1,6 @@
+.bottomBar {
+    box-shadow:
+        0px 0px 1px rgba(33,41,52,0.1),
+        0px -4px 6px -1px rgba(33,41,52,0.1),
+        0px -2px 4px -1px rgba(33,41,52,0.06);
+}

--- a/src/bottom-bar/data-item-bar.js
+++ b/src/bottom-bar/data-item-bar.js
@@ -18,16 +18,10 @@ export default function DataItemBar() {
     )
 
     // We don't want to display "default"
-    const categoryOptionsWithoutDefaultOption = categoryOptions.filter(
-        ({ isDefault }) => !isDefault
-    )
-
-    const categoryOptionComboDisplayName =
-        categoryOptionsWithoutDefaultOption.length
-            ? categoryOptions
-                  .map(({ displayShortName }) => displayShortName)
-                  .reduce((acc, cur) => `${acc}, ${cur}`)
-            : ''
+    const categoryOptionComboDisplayName = categoryOptions
+        .filter(({ isDefault }) => !isDefault)
+        .map(({ displayShortName }) => displayShortName)
+        .join(', ')
 
     return (
         <div className={styles.container}>

--- a/src/bottom-bar/data-item-bar.js
+++ b/src/bottom-bar/data-item-bar.js
@@ -1,0 +1,45 @@
+import i18n from '@dhis2/d2-i18n'
+import { Button } from '@dhis2/ui'
+import React from 'react'
+import { useMetadata, selectors } from '../metadata/index.js'
+import { useRightHandPanelContext } from '../right-hand-panel/index.js'
+import { useCurrentItemContext } from '../shared/index.js'
+import styles from './data-item-bar.module.css'
+
+export default function DataItemBar() {
+    const rightHandPanel = useRightHandPanelContext()
+    const { item } = useCurrentItemContext()
+    const { data: metadata } = useMetadata()
+
+    const dataElement = selectors.getDataElementById(metadata, item.dataElement)
+    const categoryOptions = selectors.getCategoryOptionsByCategoryOptionComboId(
+        metadata,
+        item.categoryOptionCombo
+    )
+
+    // We don't want to display "default"
+    const categoryOptionsWithoutDefaultOption = categoryOptions.filter(
+        ({ isDefault }) => !isDefault
+    )
+
+    const categoryOptionComboDisplayName =
+        categoryOptionsWithoutDefaultOption.length
+            ? categoryOptions
+                  .map(({ displayShortName }) => displayShortName)
+                  .reduce((acc, cur) => `${acc}, ${cur}`)
+            : ''
+
+    return (
+        <div className={styles.container}>
+            <span className={styles.name}>
+                {dataElement.displayShortName}
+                {categoryOptionComboDisplayName &&
+                    `| ${categoryOptionComboDisplayName}`}
+            </span>
+
+            <Button small onClick={() => rightHandPanel.show('data-details')}>
+                {i18n.t('View details')}
+            </Button>
+        </div>
+    )
+}

--- a/src/bottom-bar/data-item-bar.module.css
+++ b/src/bottom-bar/data-item-bar.module.css
@@ -1,0 +1,11 @@
+.container {
+    display: flex;
+    padding: 4px 12px;
+    align-items: center;
+    border-bottom: 1px solid var(--colors-grey400);
+}
+
+.name {
+    display: block;
+    margin-right: 4px;
+}

--- a/src/bottom-bar/main-tool-bar.js
+++ b/src/bottom-bar/main-tool-bar.js
@@ -1,0 +1,64 @@
+import i18n from '@dhis2/d2-i18n'
+import { Button, IconErrorFilled16, IconInfo16, colors } from '@dhis2/ui'
+import cx from 'classnames'
+import React from 'react'
+import styles from './main-tool-bar.module.css'
+
+export default function MainToolBar() {
+    const canValidate = false // @TODO(canValidate): implement me!
+    const isComplete = true // @TODO(isComplete): implement me!
+    const complete = () => console.log('@TODO(complete): implement me!')
+    const incomplete = () => console.log('@TODO(incomplete): implement me!')
+    const validate = () => console.log('@TODO(validate): implement me!')
+    const completedBy = 'Firstname Lastname' // @TODO(completedBy): implement me!
+
+    return (
+        <div className={styles.container}>
+            <Button
+                disabled={!canValidate}
+                className={styles.toolbarItem}
+                onClick={validate}
+            >
+                {i18n.t('Run validation')}
+            </Button>
+
+            <Button
+                className={styles.toolbarItem}
+                onClick={isComplete ? incomplete : complete}
+            >
+                {isComplete
+                    ? i18n.t('Mark incomplete')
+                    : i18n.t('Mark complete')}
+            </Button>
+
+            <button className={cx(styles.goToInvalidValue, styles.toolbarItem)}>
+                <span className={cx(styles.icon, styles.goToInvalidValueIcon)}>
+                    <IconErrorFilled16 color={colors.red700} />
+                </span>
+
+                <span className={styles.goToInvalidValueLabel}>
+                    {i18n.t('3 invalid values not saved')}
+                </span>
+            </button>
+
+            {isComplete && (
+                <span
+                    className={cx(styles.completionSummary, styles.toolbarItem)}
+                >
+                    <span
+                        className={cx(styles.icon, styles.goToInvalidValueIcon)}
+                    >
+                        <IconInfo16 color={colors.grey700} />
+                    </span>
+
+                    <span>
+                        <span className={styles.completedByLabel}>
+                            {i18n.t('Completed by')}
+                        </span>
+                        {completedBy}
+                    </span>
+                </span>
+            )}
+        </div>
+    )
+}

--- a/src/bottom-bar/main-tool-bar.module.css
+++ b/src/bottom-bar/main-tool-bar.module.css
@@ -1,0 +1,46 @@
+.container {
+    display: flex;
+    align-items: center;
+    padding: 8px 12px;
+}
+
+.toolbarItem {
+    display: flex;
+    margin-right: 12px;
+}
+
+.toolbarItem:last-child {
+    /*
+     * This way we avoid a break/overflow when the
+     * margin would "spill over" otherwise
+     */
+    margin-right: 0;
+}
+
+.icon {
+    display: block;
+    margin-right: 4px;
+    height: 16px;
+    width: 16px;
+}
+
+.goToInvalidValue, .completionSummary {
+    display: flex;
+    align-items: center;
+    border: 0;
+    padding: 4px;
+    font-size: 14px;
+    line-height: 18px;
+}
+
+.goToInvalidValue {
+    background: var(--colors-red200);
+}
+
+.completionSummary {
+    background: var(--colors-blue050);
+}
+
+.completedByLabel:after {
+    content: ' ';
+}

--- a/src/data-workspace/data-entry-cell/entry-field-input.js
+++ b/src/data-workspace/data-entry-cell/entry-field-input.js
@@ -100,7 +100,6 @@ export function EntryFieldInput({
         const { key, shiftKey } = event
 
         if (shiftKey && key === 'Enter') {
-            currentItemContext.setItem(currentItem)
             rightHandPanel.show('data-details')
         } else if (key === 'ArrowDown' || key === 'Enter') {
             event.preventDefault()
@@ -112,6 +111,7 @@ export function EntryFieldInput({
     }
 
     const onFocus = () => {
+        currentItemContext.setItem(currentItem)
         rightHandPanel.hide()
     }
 

--- a/src/data-workspace/data-workspace.js
+++ b/src/data-workspace/data-workspace.js
@@ -2,6 +2,8 @@ import i18n from '@dhis2/d2-i18n'
 import { CenteredContent, CircularLoader, NoticeBox } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { MutationIndicator } from '../app/mutation-indicator/index.js'
+import { BottomBar } from '../bottom-bar/index.js'
 import {
     useContextSelection,
     useIsValidSelection,
@@ -53,8 +55,24 @@ export const DataWorkspace = ({ selectionHasNoFormMessage }) => {
         <FinalFormWrapper
             dataValueSet={initialDataValuesFetch.data?.dataValues}
         >
-            <div id="data-workspace" className={styles.wrapper}>
-                <EntryForm dataSet={dataSet} />
+            <div className={styles.wrapper}>
+                <main id="data-workspace" className={styles.formWrapper}>
+                    <div className={styles.formArea}>
+                        <EntryForm dataSet={dataSet} />
+                    </div>
+                </main>
+
+                <footer className={styles.footer}>
+                    <div
+                        // This div and its content will be removed
+                        // once we can display this in the headerbar
+                        className={styles.mutationIndicator}
+                    >
+                        <MutationIndicator />
+                    </div>
+
+                    <BottomBar />
+                </footer>
             </div>
         </FinalFormWrapper>
     )

--- a/src/data-workspace/data-workspace.module.css
+++ b/src/data-workspace/data-workspace.module.css
@@ -1,10 +1,36 @@
 .wrapper {
+    height: 100%;
+    display: grid;
+    grid-template-areas:
+        'workspace'
+        'footer';
+    grid-template-rows: minmax(0, 1fr) auto;
+}
+
+.formWrapper {
+    grid-area: workspace;
+    padding: 8px 0;
+    overflow: auto;
+}
+
+.formArea {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     gap: 16px;
-    background-color: #fff;
     min-width: 600px;
     padding: 8px;
-    overflow: auto;
+    background-color: #fff;
+}
+
+.footer {
+    grid-area: footer;
+    position: relative;
+}
+
+.mutationIndicator {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateY(-100%);
 }

--- a/src/metadata/selectors.js
+++ b/src/metadata/selectors.js
@@ -72,13 +72,14 @@ export const getCategoryOptionsByCategoryOptionComboId = createCachedSelector(
     (metadata, categoryOptionComboId) => {
         const categoryCombos = Object.values(metadata.categoryCombos)
 
-        // "outer:" is a positional label that can be used to break multiple
-        // loops: https://stackoverflow.com/a/1564838
         for (const categoryCombo of categoryCombos) {
             for (const curCategoryOptionCombo of categoryCombo.categoryOptionCombos) {
                 if (curCategoryOptionCombo.id === categoryOptionComboId) {
-                    const categoryOptions = Object.values(metadata.categoryOptions)
-                    const { categoryOptions: curCategoryOptions } = curCategoryOptionCombo
+                    const categoryOptions = Object.values(
+                        metadata.categoryOptions
+                    )
+                    const { categoryOptions: curCategoryOptions } =
+                        curCategoryOptionCombo
 
                     return categoryOptions.filter(({ id }) =>
                         curCategoryOptions.includes(id)

--- a/src/metadata/selectors.js
+++ b/src/metadata/selectors.js
@@ -70,28 +70,24 @@ export const getCategoryOptionsByCategoryOptionComboId = createCachedSelector(
     (metadata) => metadata,
     (_, categoryOptionComboId) => categoryOptionComboId,
     (metadata, categoryOptionComboId) => {
-        let categoryOptionCombo
-
         const categoryCombos = Object.values(metadata.categoryCombos)
 
         // "outer:" is a positional label that can be used to break multiple
         // loops: https://stackoverflow.com/a/1564838
-        outer: for (const categoryCombo of categoryCombos) {
+        for (const categoryCombo of categoryCombos) {
             for (const curCategoryOptionCombo of categoryCombo.categoryOptionCombos) {
                 if (curCategoryOptionCombo.id === categoryOptionComboId) {
-                    categoryOptionCombo = curCategoryOptionCombo
-                    break outer
+                    const categoryOptions = Object.values(metadata.categoryOptions)
+                    const { categoryOptions: curCategoryOptions } = curCategoryOptionCombo
+
+                    return categoryOptions.filter(({ id }) =>
+                        curCategoryOptions.includes(id)
+                    )
                 }
             }
         }
 
-        if (!categoryOptionCombo) {
-            return []
-        }
-
-        return Object.values(metadata.categoryOptions).filter(({ id }) =>
-            categoryOptionCombo.categoryOptions.includes(id)
-        )
+        return []
     }
 )((_, categoryOptionComboId) => categoryOptionComboId)
 

--- a/src/metadata/selectors.js
+++ b/src/metadata/selectors.js
@@ -66,6 +66,35 @@ export const getCategoryOptionCombosByCategoryComboId = (
  * selectors that should have a cache per parameter (say an id) should use re-reselect.
  */
 
+export const getCategoryOptionsByCategoryOptionComboId = createCachedSelector(
+    (metadata) => metadata,
+    (_, categoryOptionComboId) => categoryOptionComboId,
+    (metadata, categoryOptionComboId) => {
+        let categoryOptionCombo
+
+        const categoryCombos = Object.values(metadata.categoryCombos)
+
+        // "outer:" is a positional label that can be used to break multiple
+        // loops: https://stackoverflow.com/a/1564838
+        outer: for (const categoryCombo of categoryCombos) {
+            for (const curCategoryOptionCombo of categoryCombo.categoryOptionCombos) {
+                if (curCategoryOptionCombo.id === categoryOptionComboId) {
+                    categoryOptionCombo = curCategoryOptionCombo
+                    break outer
+                }
+            }
+        }
+
+        if (!categoryOptionCombo) {
+            return []
+        }
+
+        return Object.values(metadata.categoryOptions).filter(({ id }) =>
+            categoryOptionCombo.categoryOptions.includes(id)
+        )
+    }
+)((_, categoryOptionComboId) => categoryOptionComboId)
+
 /**
  * @param {*} metadata
  * @param {string} dataSetId

--- a/src/metadata/selectors.test.js
+++ b/src/metadata/selectors.test.js
@@ -703,7 +703,10 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
         }
 
         const expected = []
-        const actual = getCategoryOptionsByCategoryOptionComboId(metadata, 'coc-id-1')
+        const actual = getCategoryOptionsByCategoryOptionComboId(
+            metadata,
+            'coc-id-1'
+        )
 
         expect(actual).toEqual(expected)
     })
@@ -713,14 +716,26 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
             categoryCombos: {
                 'cc-id-1': {
                     categoryOptionCombos: [
-                        { id: 'coc-id-1', categoryOptions: ['co-id-1', 'co-id-2'] },
-                        { id: 'coc-id-2', categoryOptions: ['co-id-3', 'co-id-4'] },
+                        {
+                            id: 'coc-id-1',
+                            categoryOptions: ['co-id-1', 'co-id-2'],
+                        },
+                        {
+                            id: 'coc-id-2',
+                            categoryOptions: ['co-id-3', 'co-id-4'],
+                        },
                     ],
                 },
                 'cc-id-2': {
                     categoryOptionCombos: [
-                        { id: 'coc-id-3', categoryOptions: ['co-id-5', 'co-id-6'] },
-                        { id: 'coc-id-4', categoryOptions: ['co-id-6', 'co-id-8'] },
+                        {
+                            id: 'coc-id-3',
+                            categoryOptions: ['co-id-5', 'co-id-6'],
+                        },
+                        {
+                            id: 'coc-id-4',
+                            categoryOptions: ['co-id-6', 'co-id-8'],
+                        },
                     ],
                 },
             },
@@ -733,11 +748,14 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
                 'co-id-6': { id: 'co-id-6' },
                 'co-id-7': { id: 'co-id-7' },
                 'co-id-8': { id: 'co-id-8' },
-            }
+            },
         }
 
         const expected = [{ id: 'co-id-1' }, { id: 'co-id-2' }]
-        const actual = getCategoryOptionsByCategoryOptionComboId(metadata, 'coc-id-1')
+        const actual = getCategoryOptionsByCategoryOptionComboId(
+            metadata,
+            'coc-id-1'
+        )
 
         expect(actual).toEqual(expected)
     })

--- a/src/metadata/selectors.test.js
+++ b/src/metadata/selectors.test.js
@@ -9,6 +9,7 @@ import {
     getCategoryOptionCombosByCategoryComboId,
     getCategoryOptions,
     getCategoryOptionsByCategoryId,
+    getCategoryOptionsByCategoryOptionComboId,
     getCoCByCategoryOptions,
     getDataElements,
     getDataElementsByDataSetId,
@@ -679,5 +680,65 @@ describe('getCoCByCategoryOptions', () => {
         expect(consoleWarnSpy).toHaveBeenCalledWith(
             `Could not find categoryOptionCombo for catCombo ${categoryComboId}, with categoryOptions: ${categoryOptionIds.join()}`
         )
+    })
+})
+
+describe('getCategoryOptionsByCategoryOptionComboId', () => {
+    it('should return an empty array when no coc can be found', () => {
+        const metadata = {
+            categoryCombos: {
+                'cc-id-1': {
+                    categoryOptionCombos: [
+                        { id: 'coc-id-2' },
+                        { id: 'coc-id-3' },
+                    ],
+                },
+                'cc-id-2': {
+                    categoryOptionCombos: [
+                        { id: 'coc-id-4' },
+                        { id: 'coc-id-5' },
+                    ],
+                },
+            },
+        }
+
+        const expected = []
+        const actual = getCategoryOptionsByCategoryOptionComboId(metadata, 'coc-id-1')
+
+        expect(actual).toEqual(expected)
+    })
+
+    it('should return the category options when a coc was found', () => {
+        const metadata = {
+            categoryCombos: {
+                'cc-id-1': {
+                    categoryOptionCombos: [
+                        { id: 'coc-id-1', categoryOptions: ['co-id-1', 'co-id-2'] },
+                        { id: 'coc-id-2', categoryOptions: ['co-id-3', 'co-id-4'] },
+                    ],
+                },
+                'cc-id-2': {
+                    categoryOptionCombos: [
+                        { id: 'coc-id-3', categoryOptions: ['co-id-5', 'co-id-6'] },
+                        { id: 'coc-id-4', categoryOptions: ['co-id-6', 'co-id-8'] },
+                    ],
+                },
+            },
+            categoryOptions: {
+                'co-id-1': { id: 'co-id-1' },
+                'co-id-2': { id: 'co-id-2' },
+                'co-id-3': { id: 'co-id-3' },
+                'co-id-4': { id: 'co-id-4' },
+                'co-id-5': { id: 'co-id-5' },
+                'co-id-6': { id: 'co-id-6' },
+                'co-id-7': { id: 'co-id-7' },
+                'co-id-8': { id: 'co-id-8' },
+            }
+        }
+
+        const expected = [{ id: 'co-id-1' }, { id: 'co-id-2' }]
+        const actual = getCategoryOptionsByCategoryOptionComboId(metadata, 'coc-id-1')
+
+        expect(actual).toEqual(expected)
     })
 })


### PR DESCRIPTION
Closes [TECH-1210](https://dhis2.atlassian.net/browse/TECH-1210)

* Refactors the layout a little: Puts the footer into the data workspace
  * I did this because the app is supposed to display the footer only when rendering a form. The data workspace renders the form conditionally and I didn't want to duplicate the conditions in the footer / app
  * Marking @ismay as a reviewer as he's the one who created this part of the app
* Adds the UI + functionality for the "data item bar" (the upper one; only displayed when focusing an item)
* Adds the UI for the "main tool bar", but not the functionality (the lower one; always displayed)
  * Marking @KaiVandivier as a reviewer as he's already working on the server side validation which includes the missing functionality in the footer's main tool bar)

EDIT: I talked to @ismay about the refactoring of the layout and we concluded that this topic can be seen from two different angles:

**The footer is a global part of the layout**
When looking at the UI specs, the footer could be regarded as app-wide. On the `development` branch, the layout is in one location (the layout component and its styles).

**The footer is a part of the data workspace**
When looking at the functionality and the position in the app, the footer seems to be a part of the data workspace itself. The condition when to render to footer is tightly coupled to what the data workspace component renders.

My motivation for moving the footer to the data workspace was that otherwise we'd have to either introduce state in the app component and set/update that state from within the data workspace component or duplicate the conditions and copy them from the data workspace component into the app component.

I'm wondering about how others see this. Do you think the footer is supposed to be an app-wide component and we should keep it in the layout component or does the footer's functionality and position in the app justify moving it to the data workspace?

_The `<MutationIndicator />`, that's been rendered by the footer is actually a global piece, but its current location is just a workaround for not being able to display that information in the headerbar right now_