### PR TITLE
feat(custom-forms): add support for total fields

### DIFF
--- a/src/data-workspace/custom-form/custom-form.js
+++ b/src/data-workspace/custom-form/custom-form.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import { useFormState } from 'react-final-form'
 import useCustomForm from '../../custom-forms/use-custom-form.js'
 import { useMetadata } from '../../metadata/use-metadata.js'
 import styles from './custom-form.module.css'
@@ -11,6 +12,7 @@ import { parseHtmlToReact } from './parse-html-to-react.js'
  * For more info see ./docs/custom-froms.md
  */
 export const CustomForm = ({ dataSet }) => {
+    const formState = useFormState()
     const { data: customForm } = useCustomForm({
         id: dataSet.dataEntryForm.id,
         version: dataSet.version,
@@ -19,7 +21,7 @@ export const CustomForm = ({ dataSet }) => {
 
     return customForm ? (
         <div className={styles.customForm}>
-            {parseHtmlToReact(customForm.htmlCode, metadata)}
+            {parseHtmlToReact(customForm.htmlCode, metadata, formState)}
         </div>
     ) : null
 }

--- a/src/data-workspace/custom-form/parse-html-to-react.js
+++ b/src/data-workspace/custom-form/parse-html-to-react.js
@@ -3,14 +3,14 @@ import React from 'react'
 import { replaceInputNode } from './replace-input-node.js'
 import { replaceTdNode } from './replace-td-node.js'
 
-export const parseHtmlToReact = (htmlCode, metadata) =>
+export const parseHtmlToReact = (htmlCode, metadata, formState) =>
     parse(htmlCode, {
         replace: (domNode) => {
             switch (domNode.name) {
                 case 'input':
                     return replaceInputNode(domNode, metadata)
                 case 'td':
-                    return replaceTdNode(domNode)
+                    return replaceTdNode(domNode, formState)
                 case 'script':
                     // remove script tags
                     return <></>

--- a/src/data-workspace/custom-form/replace-td-node.js
+++ b/src/data-workspace/custom-form/replace-td-node.js
@@ -20,6 +20,8 @@ const computeTotal = (values) => {
 }
 
 const replaceTotalCell = (dataElementId, formState) => {
+    // Get values from all cells associated with this data element from form state and sum them.
+    // Object passed to computeTotal should look like `{ [cocId1]: val1, [cocId2]: val2, ... }`
     const total = computeTotal(formState.values[dataElementId])
 
     return <TotalCell>{total}</TotalCell>


### PR DESCRIPTION
Code-wise it would have made a lot more sense to replace the input tag, but that caused issues with the table-cell's background color. I couldn't get the content of the `td` to be filled completely, so I ended up with some whitespace inside the `td`. So I did it this way instead, replacing the `td`. Another advantage of this was that I could re-use the `TotalCell` which already came with the right styles.

To test this functionality, I recommend using the EPI Stock dataset.