### PR TITLE
fix: enable contextual help side bar

### DIFF
--- a/src/context-selection/contextual-help-sidebar/contextual-help-sidebar.js
+++ b/src/context-selection/contextual-help-sidebar/contextual-help-sidebar.js
@@ -1,18 +1,17 @@
 import i18n from '@dhis2/d2-i18n'
 import React from 'react'
-import { useRightHandPanelContext } from '../../right-hand-panel/index.js'
-import { Sidebar, Title } from '../../shared/index.js'
+import { Sidebar, SidebarProps, Title } from '../../shared/index.js'
 import CellsLegend from './cells-legend.js'
 import Shortcuts from './shortcuts.js'
 
-export default function ContextualHelpSidebar() {
-    const rightHandPanel = useRightHandPanelContext()
-
+export default function ContextualHelpSidebar({ hide }) {
     return (
         <Sidebar>
-            <Title onClose={rightHandPanel.hide}>{i18n.t('Help')}</Title>
+            <Title onClose={hide}>{i18n.t('Help')}</Title>
             <CellsLegend />
             <Shortcuts />
         </Sidebar>
     )
 }
+
+ContextualHelpSidebar.propTypes = SidebarProps

--- a/src/data-workspace/data-details-sidebar/data-details-sidebar.js
+++ b/src/data-workspace/data-details-sidebar/data-details-sidebar.js
@@ -14,6 +14,7 @@ import {
     ExpandableUnit,
     useApiAttributeParams,
     useCurrentItemContext,
+    SidebarProps,
 } from '../../shared/index.js'
 import * as queryKeyFactory from '../query-key-factory.js'
 import AuditLog from './audit-log.js'
@@ -111,3 +112,4 @@ export default function DataDetailsSidebar() {
         </Sidebar>
     )
 }
+DataDetailsSidebar.propTypes = SidebarProps

--- a/src/right-hand-panel/right-hand-panel.js
+++ b/src/right-hand-panel/right-hand-panel.js
@@ -1,12 +1,12 @@
 import React, { useContext } from 'react'
-// import { ContextualHelpSidebar } from '../context-selection/index.js'
+import { ContextualHelpSidebar } from '../context-selection/index.js'
 import { DataDetailsSidebar } from '../data-workspace/index.js'
 import RightHandPanelContext from './right-hand-panel-context.js'
 import styles from './right-hand-panel.module.css'
 
 const idSidebarMap = {
     'data-details': DataDetailsSidebar,
-    // 'contextual-help': ContextualHelpSidebar,
+    'contextual-help': ContextualHelpSidebar,
 }
 
 export default function RightHandPanel() {

--- a/src/right-hand-panel/right-hand-panel.js
+++ b/src/right-hand-panel/right-hand-panel.js
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react'
-import { ContextualHelpSidebar } from '../context-selection/index.js'
+import { ContextualHelpSidebar } from '../context-selection/contextual-help-sidebar/index.js'
 import { DataDetailsSidebar } from '../data-workspace/index.js'
 import RightHandPanelContext from './right-hand-panel-context.js'
 import styles from './right-hand-panel.module.css'
@@ -10,7 +10,7 @@ const idSidebarMap = {
 }
 
 export default function RightHandPanel() {
-    const { id } = useContext(RightHandPanelContext)
+    const { id, show, hide } = useContext(RightHandPanelContext)
     const SidebarComponent = idSidebarMap[id]
 
     if (id && !SidebarComponent) {
@@ -23,7 +23,7 @@ export default function RightHandPanel() {
 
     return (
         <div className={styles.wrapper}>
-            <SidebarComponent />
+            <SidebarComponent show={show} hide={hide} />
         </div>
     )
 }

--- a/src/shared/sidebar/index.js
+++ b/src/shared/sidebar/index.js
@@ -1,3 +1,4 @@
 export { default as Sidebar } from './sidebar.js'
 export { default as Title } from './title.js'
 export { default as ExpandableUnit } from './expandable-unit.js'
+export { default as SidebarProps } from './sidebar-props.js'

--- a/src/shared/sidebar/sidebar-props.js
+++ b/src/shared/sidebar/sidebar-props.js
@@ -1,0 +1,8 @@
+import PropTypes from 'prop-types'
+
+const SidebarProps = {
+    hide: PropTypes.func,
+    show: PropTypes.func,
+}
+
+export default SidebarProps


### PR DESCRIPTION
Ensure the sidebar for contextual help is displaying without crashing the app

| Before | After |
| --- | -- |
| <img width="833" alt="image" src="https://user-images.githubusercontent.com/1014725/176408919-34b9adf3-7ce2-4617-9933-6a6633b2384a.png"> | <img width="426" alt="image" src="https://user-images.githubusercontent.com/1014725/176408831-999de1fd-53fe-4037-98ab-d0d28255aa59.png"> |