### PR TITLE
fix: add link to file input control

### DIFF
--- a/src/data-workspace/inputs/file-inputs.js
+++ b/src/data-workspace/inputs/file-inputs.js
@@ -8,6 +8,7 @@ import {
     useDeleteDataValueMutation,
     useUploadDataValueFileMutation,
 } from '../use-data-value-mutation/index.js'
+import useFileInputUrl from '../use-file-input-url.js'
 import styles from './inputs.module.css'
 
 const formatFileSize = (size) => {
@@ -33,6 +34,8 @@ export const FileResourceInput = ({
             onChange: true,
         },
     })
+
+    const fileLink = useFileInputUrl(dataValueParams)
 
     // When the app loads, if there's a file saved for this data value,
     // the value of this input will be UID of a file resource as populated
@@ -100,7 +103,9 @@ export const FileResourceInput = ({
             {file ? (
                 <>
                     <IconAttachment16 color={colors.grey700} />
-                    {`${file.name} (${formatFileSize(file.size)})`}
+                    <a href={fileLink}>{`${file.name} (${formatFileSize(
+                        file.size
+                    )})`}</a>
                     <Button
                         small
                         secondary

--- a/src/data-workspace/use-file-input-url.js
+++ b/src/data-workspace/use-file-input-url.js
@@ -1,0 +1,14 @@
+import { useConfig } from '@dhis2/app-runtime'
+
+export default function useFileInputUrl(dataValueParams) {
+    const { baseUrl } = useConfig()
+    if (!dataValueParams) {
+        return ''
+    }
+
+    const urlParams = new URLSearchParams(dataValueParams).toString()
+
+    const fileUploadLink = `${baseUrl}/api/dataValues/files?${urlParams}`
+
+    return fileUploadLink
+}

--- a/src/data-workspace/use-file-input-url.test.js
+++ b/src/data-workspace/use-file-input-url.test.js
@@ -1,0 +1,19 @@
+import { useConfig } from '@dhis2/app-runtime'
+import { renderHook } from '@testing-library/react-hooks'
+import useFileInputUrl from './use-file-input-url.js'
+
+jest.mock('@dhis2/app-runtime', () => ({
+    useConfig: jest.fn(),
+}))
+
+describe('useFileInput hook', () => {
+    it('should return the file download Url', () => {
+        useConfig.mockImplementation(() => ({ baseUrl: 'http://local:8030' }))
+        const { result } = renderHook(() =>
+            useFileInputUrl({ pe: '2022Q1', ou: 'ImspTQPwCqd' })
+        )
+        expect(result.current).toEqual(
+            'http://local:8030/api/dataValues/files?pe=2022Q1&ou=ImspTQPwCqd'
+        )
+    })
+})


### PR DESCRIPTION
adds ability to download uploaded files in file-input control

closes [TECH-1229](https://dhis2.atlassian.net/browse/TECH-1229)

| Before | after |
| ---- | --- |
| <img width="796" alt="image" src="https://user-images.githubusercontent.com/1014725/176493023-c57178c2-315d-4827-a76b-3525d632b236.png"> | ![file-input-link](https://user-images.githubusercontent.com/1014725/176492874-8ad00d71-541c-4944-834f-79b1fbff2f22.gif) |