### PR TITLE
fix: style file link according to spec

### DIFF
--- a/src/data-workspace/inputs/file-inputs.js
+++ b/src/data-workspace/inputs/file-inputs.js
@@ -97,15 +97,15 @@ export const FileResourceInput = ({
 
     // styles:
     // todo: make file input button `secondary` style to match design spec
-    // todo: make file summary a clickable link to view the file (focusable)
     return (
         <div className={styles.fileInputWrapper}>
             {file ? (
                 <>
                     <IconAttachment16 color={colors.grey700} />
-                    <a href={fileLink}>{`${file.name} (${formatFileSize(
-                        file.size
-                    )})`}</a>
+                    <a href={fileLink} className={styles.fileLink}>
+                        {file.name}
+                    </a>
+                    {` (${formatFileSize(file.size)})`}
                     <Button
                         small
                         secondary

--- a/src/data-workspace/inputs/inputs.module.css
+++ b/src/data-workspace/inputs/inputs.module.css
@@ -68,9 +68,8 @@
     /* Fixes extra padding at the bottom of the UI component */
     margin-bottom: -4px;
 }
-.fileSummary {
-    display: flex;
-    align-items: center;
+.fileLink {
+    color: var(--colors-grey700);
 }
 .deleteFileButton {
     composes: whiteButton;


### PR DESCRIPTION
Follow-up to #82 

Adds link styles according to [this specification document](https://docs.google.com/document/d/1NDMM-FAGCdM41n8ShnQuS6snvKvdSWNW-rky23cio_I/edit#heading=h.g44lloa2cs97) 🙂

![Screen Shot 2022-06-30 at 5 43 44 PM](https://user-images.githubusercontent.com/49666798/176719920-ae3ce828-8376-4b20-bb96-0015a0186fcb.png)
