### PR TITLE
fix: make sure integer validation does not allow decimal

### DIFF
--- a/src/data-workspace/inputs/generic-input.js
+++ b/src/data-workspace/inputs/generic-input.js
@@ -1,10 +1,4 @@
-import {
-    email,
-    integer,
-    internationalPhoneNumber,
-    number,
-    url,
-} from '@dhis2/ui-forms'
+import { email, internationalPhoneNumber, number, url } from '@dhis2/ui-forms'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import { useField } from 'react-final-form'
@@ -15,6 +9,7 @@ import { InputPropTypes } from './utils.js'
 import {
     // date,
     // dateTime,
+    integer,
     integerPositive,
     integerZeroOrPositive,
     integerNegative,

--- a/src/data-workspace/inputs/validators.js
+++ b/src/data-workspace/inputs/validators.js
@@ -1,6 +1,6 @@
 import i18n from '@dhis2/d2-i18n'
 import {
-    integer,
+    integer as createInteger,
     createMinNumber,
     composeValidators,
     createMaxNumber,
@@ -47,6 +47,13 @@ export const time = (value) =>
         : i18n.t('Please provide a valid time in the format HH{{c}}MM', {
               c: ':',
           })
+
+const nonDecimal = (value) =>
+    !value || !/(\.|,)/.test(value)
+        ? undefined
+        : i18n.t('Please provide a round number without decimals')
+
+export const integer = composeValidators(createInteger, nonDecimal)
 
 export const integerPositive = composeValidators(integer, createMinNumber(1))
 export const integerZeroOrPositive = composeValidators(


### PR DESCRIPTION
Closes [TECH-1230](https://dhis2.atlassian.net/browse/TECH-1230)

### Description
This fix ensures that a value such as `6.0` is not allowed by client side validation. Currently the client-side allows it, but then it's rejected by the API.

| Before | After |
| --- | --- |
| The value is accepted by client then rejected by API | client-side validation catches the decimal point |
| <img width="493" alt="image" src="https://user-images.githubusercontent.com/1014725/177374579-4e27e4ec-6c5e-4585-8cfb-d10d043110d8.png"> | <img width="698" alt="image" src="https://user-images.githubusercontent.com/1014725/177374438-476fc34f-6210-4955-95be-1600ed225f46.png"> |