### PR TITLE
refactor: optimize re-renders

### DIFF
--- a/src/data-workspace/category-combo-table/category-combo-table-header.js
+++ b/src/data-workspace/category-combo-table/category-combo-table-header.js
@@ -2,62 +2,66 @@ import i18n from '@dhis2/d2-i18n'
 import { TableRowHead, TableCellHead } from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useMetadata, selectors } from '../../metadata/index.js'
 import { useActiveCell } from '../data-entry-cell/index.js'
 import styles from './category-combo-table.module.css'
 import { PaddingCell } from './padding-cell.js'
 import { TotalHeader } from './total-cells.js'
 
+// Computes the span and columns to render in each category-row
+// columns are category-options, and needs to be repeated in case of multiple categories
+const useCategoryColumns = (categories, numberOfCoCs) => {
+    const { data: metadata } = useMetadata()
+    return useMemo(() => {
+        let catColSpan = numberOfCoCs
+        return categories.map((c) => {
+            const categoryOptions = selectors.getCategoryOptionsByCategoryId(
+                metadata,
+                c.id
+            )
+            const nrOfOptions = c.categoryOptions.length
+            // catColSpan should always be equal to nrOfOptions in last iteration
+            // unless anomaly with categoryOptionCombo-generation server-side
+            if (nrOfOptions > 0 && catColSpan >= nrOfOptions) {
+                // calculate colSpan for current options
+                // this is the span for each option, not the "total" span of the row
+                catColSpan = catColSpan / nrOfOptions
+                // when table have multiple categories, options need to be repeated for each disaggregation "above" current-category
+                const repeat = numberOfCoCs / (catColSpan * nrOfOptions)
+
+                const columnsToRender = new Array(repeat)
+                    .fill(0)
+                    .flatMap(() => categoryOptions)
+
+                return {
+                    span: catColSpan,
+                    columns: columnsToRender,
+                    category: c,
+                }
+            } else {
+                console.warn(
+                    `Category ${c.displayFormName} malformed. Number of options: ${nrOfOptions}, span: ${catColSpan}`
+                )
+            }
+            return c
+        })
+    }, [metadata, categories, numberOfCoCs])
+}
+
 export const CategoryComboTableHeader = ({
-    dataElements,
     renderRowTotals,
     paddingCells,
     categoryOptionCombos,
     categories,
+    checkTableActive,
 }) => {
-    const { data: metadata } = useMetadata()
     const { deId: activeDeId, cocId: activeCocId } = useActiveCell()
 
-    // Computes the span and repeats for each columns in a category-row.
-    // Repeats are the number of times the options in a category needs to be rendered per category-row
-    let catColSpan = categoryOptionCombos.length
-    const rowToColumnsMap = categories.map((c) => {
-        const categoryOptions = selectors.getCategoryOptionsByCategoryId(
-            metadata,
-            c.id
-        )
-        const nrOfOptions = c.categoryOptions.length
-        // catColSpan should always be equal to nrOfOptions in last iteration
-        // unless anomaly with categoryOptionCombo-generation server-side
-        if (nrOfOptions > 0 && catColSpan >= nrOfOptions) {
-            // calculate colSpan for current options
-            // this is the span for each option, not the "total" span of the row
-            catColSpan = catColSpan / nrOfOptions
-            // when table have multiple categories, options need to be repeated for each disaggregation "above" current-category
-            const repeat =
-                categoryOptionCombos.length / (catColSpan * nrOfOptions)
-
-            const columnsToRender = new Array(repeat)
-                .fill(0)
-                .flatMap(() => categoryOptions)
-
-            return {
-                span: catColSpan,
-                columns: columnsToRender,
-                category: c,
-            }
-        } else {
-            console.warn(
-                `Category ${c.displayFormName} malformed. Number of options: ${nrOfOptions}, span: ${catColSpan}`
-            )
-        }
-        return c
-    })
-
-    // Is the active cell in this cat-combo table? Check to see if active
-    // data element is in this CCT
-    const isThisTableActive = dataElements.some(({ id }) => id === activeDeId)
+    const rowToColumnsMap = useCategoryColumns(
+        categories,
+        categoryOptionCombos.length
+    )
 
     // Find if this column header includes the active cell's column
     const isHeaderActive = (headerIdx, headerColSpan) => {
@@ -65,7 +69,11 @@ export const CategoryComboTableHeader = ({
             (coc) => activeCocId === coc.id
         )
         const idxDiff = activeCellColIdx - headerIdx * headerColSpan
-        return isThisTableActive && idxDiff < headerColSpan && idxDiff >= 0
+        return (
+            checkTableActive(activeDeId) &&
+            idxDiff < headerColSpan &&
+            idxDiff >= 0
+        )
     }
 
     return rowToColumnsMap.map((colInfo, colInfoIndex) => {
@@ -109,22 +117,14 @@ export const CategoryComboTableHeader = ({
 }
 
 CategoryComboTableHeader.propTypes = {
-    categoryCombo: PropTypes.shape({
-        id: PropTypes.string.isRequired,
-        categoryOptionCombos: PropTypes.array,
-    }).isRequired,
     categories: PropTypes.array,
-    categoryOptionCombos: PropTypes.array,
-    dataElements: PropTypes.arrayOf(
+    // Note that this must be the sorted categoryoOptionCombos, eg. in the same order as they are rendered
+    categoryOptionCombos: PropTypes.arrayOf(
         PropTypes.shape({
-            id: PropTypes.string.isRequired,
-            categoryCombo: PropTypes.shape({
-                id: PropTypes.string,
-            }),
-            displayFormName: PropTypes.string,
-            valueType: PropTypes.string,
+            id: PropTypes.string,
         })
     ),
+    checkTableActive: PropTypes.func,
     paddingCells: PropTypes.array,
     renderRowTotals: PropTypes.bool,
 }

--- a/src/data-workspace/category-combo-table/category-combo-table-header.js
+++ b/src/data-workspace/category-combo-table/category-combo-table-header.js
@@ -1,0 +1,130 @@
+import i18n from '@dhis2/d2-i18n'
+import { TableRowHead, TableCellHead } from '@dhis2/ui'
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React from 'react'
+import { useMetadata, selectors } from '../../metadata/index.js'
+import { useActiveCell } from '../data-entry-cell/index.js'
+import styles from './category-combo-table.module.css'
+import { PaddingCell } from './padding-cell.js'
+import { TotalHeader } from './total-cells.js'
+
+export const CategoryComboTableHeader = ({
+    dataElements,
+    renderRowTotals,
+    paddingCells,
+    categoryOptionCombos,
+    categories,
+}) => {
+    const { data: metadata } = useMetadata()
+    const { deId: activeDeId, cocId: activeCocId } = useActiveCell()
+
+    // Computes the span and repeats for each columns in a category-row.
+    // Repeats are the number of times the options in a category needs to be rendered per category-row
+    let catColSpan = categoryOptionCombos.length
+    const rowToColumnsMap = categories.map((c) => {
+        const categoryOptions = selectors.getCategoryOptionsByCategoryId(
+            metadata,
+            c.id
+        )
+        const nrOfOptions = c.categoryOptions.length
+        // catColSpan should always be equal to nrOfOptions in last iteration
+        // unless anomaly with categoryOptionCombo-generation server-side
+        if (nrOfOptions > 0 && catColSpan >= nrOfOptions) {
+            // calculate colSpan for current options
+            // this is the span for each option, not the "total" span of the row
+            catColSpan = catColSpan / nrOfOptions
+            // when table have multiple categories, options need to be repeated for each disaggregation "above" current-category
+            const repeat =
+                categoryOptionCombos.length / (catColSpan * nrOfOptions)
+
+            const columnsToRender = new Array(repeat)
+                .fill(0)
+                .flatMap(() => categoryOptions)
+
+            return {
+                span: catColSpan,
+                columns: columnsToRender,
+                category: c,
+            }
+        } else {
+            console.warn(
+                `Category ${c.displayFormName} malformed. Number of options: ${nrOfOptions}, span: ${catColSpan}`
+            )
+        }
+        return c
+    })
+
+    // Is the active cell in this cat-combo table? Check to see if active
+    // data element is in this CCT
+    const isThisTableActive = dataElements.some(({ id }) => id === activeDeId)
+
+    // Find if this column header includes the active cell's column
+    const isHeaderActive = (headerIdx, headerColSpan) => {
+        const activeCellColIdx = categoryOptionCombos.findIndex(
+            (coc) => activeCocId === coc.id
+        )
+        const idxDiff = activeCellColIdx - headerIdx * headerColSpan
+        return isThisTableActive && idxDiff < headerColSpan && idxDiff >= 0
+    }
+
+    return rowToColumnsMap.map((colInfo, colInfoIndex) => {
+        const { span, columns, category } = colInfo
+        return (
+            <TableRowHead key={category.id}>
+                <TableCellHead
+                    className={styles.categoryNameHeader}
+                    colSpan={'1'}
+                >
+                    {category.displayFormName !== 'default' &&
+                        category.displayFormName}
+                </TableCellHead>
+                {columns.map((co, columnIndex) => {
+                    return (
+                        <TableCellHead
+                            key={columnIndex}
+                            className={cx(styles.tableHeader, {
+                                [styles.active]: isHeaderActive(
+                                    columnIndex,
+                                    span
+                                ),
+                            })}
+                            colSpan={span.toString()}
+                        >
+                            {co.isDefault
+                                ? i18n.t('Value')
+                                : co.displayFormName}
+                        </TableCellHead>
+                    )
+                })}
+                {paddingCells.map((_, i) => (
+                    <PaddingCell key={i} />
+                ))}
+                {renderRowTotals && colInfoIndex === 0 && (
+                    <TotalHeader rowSpan={categories.length} />
+                )}
+            </TableRowHead>
+        )
+    })
+}
+
+CategoryComboTableHeader.propTypes = {
+    categoryCombo: PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        categoryOptionCombos: PropTypes.array,
+    }).isRequired,
+    categories: PropTypes.array,
+    categoryOptionCombos: PropTypes.array,
+    dataElements: PropTypes.arrayOf(
+        PropTypes.shape({
+            id: PropTypes.string.isRequired,
+            categoryCombo: PropTypes.shape({
+                id: PropTypes.string,
+            }),
+            displayFormName: PropTypes.string,
+            valueType: PropTypes.string,
+        })
+    ),
+    paddingCells: PropTypes.array,
+    renderRowTotals: PropTypes.bool,
+}

--- a/src/data-workspace/category-combo-table/category-combo-table.js
+++ b/src/data-workspace/category-combo-table/category-combo-table.js
@@ -1,7 +1,7 @@
 import i18n from '@dhis2/d2-i18n'
 import { TableBody, TableRow, TableCell } from '@dhis2/ui'
 import PropTypes from 'prop-types'
-import React, { useMemo } from 'react'
+import React, { useMemo, useCallback } from 'react'
 import { useMetadata, selectors } from '../../metadata/index.js'
 import { cartesian } from '../../shared/utils.js'
 import { DataEntryCell, DataEntryField } from '../data-entry-cell/index.js'
@@ -55,6 +55,11 @@ export const CategoryComboTable = ({
         )
     }
 
+    const checkTableActive = useCallback(
+        (activeDeId) => dataElements.some(({ id }) => id === activeDeId),
+        [dataElements]
+    )
+
     const paddingCells =
         maxColumnsInSection > 0
             ? new Array(maxColumnsInSection - sortedCOCs.length).fill(0)
@@ -77,6 +82,7 @@ export const CategoryComboTable = ({
                 dataElements={dataElements}
                 renderRowTotals={renderRowTotals}
                 paddingCells={paddingCells}
+                checkTableActive={checkTableActive}
             />
             {filteredDataElements.map((de, i) => {
                 return (

--- a/src/data-workspace/category-combo-table/category-combo-table.js
+++ b/src/data-workspace/category-combo-table/category-combo-table.js
@@ -108,7 +108,7 @@ export const CategoryComboTable = ({
             })}
             {renderColumnTotals && (
                 <ColumnTotals
-                    paddedCells={paddingCells}
+                    paddingCells={paddingCells}
                     renderTotalSum={renderRowTotals && renderColumnTotals}
                     dataElements={dataElements}
                     categoryOptionCombos={sortedCOCs}

--- a/src/data-workspace/category-combo-table/category-combo-table.js
+++ b/src/data-workspace/category-combo-table/category-combo-table.js
@@ -1,24 +1,15 @@
 import i18n from '@dhis2/d2-i18n'
-import {
-    TableRowHead,
-    TableCellHead,
-    TableBody,
-    TableRow,
-    TableCell,
-} from '@dhis2/ui'
-import cx from 'classnames'
+import { TableBody, TableRow, TableCell } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
 import { useMetadata, selectors } from '../../metadata/index.js'
 import { cartesian } from '../../shared/utils.js'
-import {
-    DataEntryCell,
-    DataEntryField,
-    useActiveCell,
-} from '../data-entry-cell/index.js'
+import { DataEntryCell, DataEntryField } from '../data-entry-cell/index.js'
 import { getFieldId } from '../get-field-id.js'
+import { CategoryComboTableHeader } from './category-combo-table-header.js'
 import styles from './category-combo-table.module.css'
-import { TotalHeader, ColumnTotals, RowTotal } from './total-cells.js'
+import { DataElementCell } from './data-element-cell.js'
+import { ColumnTotals, RowTotal } from './total-cells.js'
 
 export const CategoryComboTable = ({
     categoryCombo,
@@ -31,7 +22,6 @@ export const CategoryComboTable = ({
     renderColumnTotals,
 }) => {
     const { data: metadata } = useMetadata()
-    const { deId: activeDeId, cocId: activeCocId } = useActiveCell()
 
     const categories = selectors.getCategoriesByCategoryComboId(
         metadata,
@@ -64,37 +54,8 @@ export const CategoryComboTable = ({
             Server: ${categoryCombo.categoryOptionCombos.length})`
         )
     }
-    // Computes the span and repeats for each columns in a category-row.
-    // Repeats are the number of times the options in a category needs to be rendered per category-row
-    let catColSpan = sortedCOCs.length
-    const rowToColumnsMap = categories.map((c) => {
-        const categoryOptions = selectors.getCategoryOptionsByCategoryId(
-            metadata,
-            c.id
-        )
-        const nrOfOptions = c.categoryOptions.length
-        if (nrOfOptions > 0 && catColSpan >= nrOfOptions) {
-            catColSpan = catColSpan / nrOfOptions
-            const repeat = sortedCOCs.length / (catColSpan * nrOfOptions)
 
-            const columnsToRender = new Array(repeat)
-                .fill(0)
-                .flatMap(() => categoryOptions)
-
-            return {
-                span: catColSpan,
-                columns: columnsToRender,
-                category: c,
-            }
-        } else {
-            console.warn(
-                `Category ${c.displayFormName} malformed. Number of options: ${nrOfOptions}, span: ${catColSpan}`
-            )
-        }
-        return c
-    })
-
-    const renderPaddedCells =
+    const paddingCells =
         maxColumnsInSection > 0
             ? new Array(maxColumnsInSection - sortedCOCs.length).fill(0)
             : []
@@ -108,69 +69,19 @@ export const CategoryComboTable = ({
     })
     const itemsHiddenCnt = dataElements.length - filteredDataElements.length
 
-    // Is the active cell in this cat-combo table? Check to see if active
-    // data element is in this CCT
-    const isThisTableActive = dataElements.some(({ id }) => id === activeDeId)
-
-    // Find if this column header includes the active cell's column
-    const isHeaderActive = (headerIdx, headerColSpan) => {
-        const activeCellColIdx = sortedCOCs.findIndex(
-            (coc) => activeCocId === coc.id
-        )
-        const idxDiff = activeCellColIdx - headerIdx * headerColSpan
-        return isThisTableActive && idxDiff < headerColSpan && idxDiff >= 0
-    }
-
     return (
         <TableBody>
-            {rowToColumnsMap.map((colInfo, colInfoIndex) => {
-                const { span, columns, category } = colInfo
-                return (
-                    <TableRowHead key={category.id}>
-                        <TableCellHead
-                            className={styles.categoryNameHeader}
-                            colSpan={'1'}
-                        >
-                            {category.displayFormName !== 'default' &&
-                                category.displayFormName}
-                        </TableCellHead>
-                        {columns.map((co, columnIndex) => {
-                            return (
-                                <TableCellHead
-                                    key={columnIndex}
-                                    className={cx(styles.tableHeader, {
-                                        [styles.active]: isHeaderActive(
-                                            columnIndex,
-                                            span
-                                        ),
-                                    })}
-                                    colSpan={span.toString()}
-                                >
-                                    {co.isDefault
-                                        ? i18n.t('Value')
-                                        : co.displayFormName}
-                                </TableCellHead>
-                            )
-                        })}
-                        {renderPaddedCells.map((_, i) => (
-                            <PaddingCell key={i} />
-                        ))}
-                        {renderRowTotals && colInfoIndex === 0 && (
-                            <TotalHeader rowSpan={categories.length} />
-                        )}
-                    </TableRowHead>
-                )
-            })}
+            <CategoryComboTableHeader
+                categoryOptionCombos={sortedCOCs}
+                categories={categories}
+                dataElements={dataElements}
+                renderRowTotals={renderRowTotals}
+                paddingCells={paddingCells}
+            />
             {filteredDataElements.map((de, i) => {
                 return (
                     <TableRow key={de.id}>
-                        <TableCell
-                            className={cx(styles.dataElementName, {
-                                [styles.active]: de.id === activeDeId,
-                            })}
-                        >
-                            {de.displayFormName}
-                        </TableCell>
+                        <DataElementCell dataElement={de} />
                         {sortedCOCs.map((coc) => (
                             <DataEntryCell key={coc.id}>
                                 <DataEntryField
@@ -182,7 +93,7 @@ export const CategoryComboTable = ({
                                 />
                             </DataEntryCell>
                         ))}
-                        {renderPaddedCells.map((_, i) => (
+                        {paddingCells.map((_, i) => (
                             <PaddingCell key={i} className={styles.tableCell} />
                         ))}
                         {renderRowTotals && (
@@ -197,7 +108,7 @@ export const CategoryComboTable = ({
             })}
             {renderColumnTotals && (
                 <ColumnTotals
-                    paddedCells={renderPaddedCells}
+                    paddedCells={paddingCells}
                     renderTotalSum={renderRowTotals && renderColumnTotals}
                     dataElements={dataElements}
                     categoryOptionCombos={sortedCOCs}

--- a/src/data-workspace/category-combo-table/category-combo-table.js
+++ b/src/data-workspace/category-combo-table/category-combo-table.js
@@ -79,7 +79,6 @@ export const CategoryComboTable = ({
             <CategoryComboTableHeader
                 categoryOptionCombos={sortedCOCs}
                 categories={categories}
-                dataElements={dataElements}
                 renderRowTotals={renderRowTotals}
                 paddingCells={paddingCells}
                 checkTableActive={checkTableActive}

--- a/src/data-workspace/category-combo-table/data-element-cell.js
+++ b/src/data-workspace/category-combo-table/data-element-cell.js
@@ -1,0 +1,32 @@
+import { TableCell } from '@dhis2/ui'
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React from 'react'
+import { useActiveCell } from '../data-entry-cell/index.js'
+import styles from './category-combo-table.module.css'
+
+export const DataElementCell = ({ dataElement }) => {
+    const { deId: activeDeId } = useActiveCell()
+    return (
+        <TableCell
+            className={cx(styles.dataElementName, {
+                [styles.active]: dataElement.id === activeDeId,
+            })}
+        >
+            {dataElement.displayFormName}
+        </TableCell>
+    )
+}
+
+DataElementCell.propTypes = {
+    dataElement: PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        categoryCombo: PropTypes.shape({
+            id: PropTypes.string,
+        }),
+        displayFormName: PropTypes.string,
+        valueType: PropTypes.string,
+    }),
+}
+
+export default DataElementCell

--- a/src/data-workspace/category-combo-table/padding-cell.js
+++ b/src/data-workspace/category-combo-table/padding-cell.js
@@ -1,0 +1,9 @@
+import { TableCell } from '@dhis2/ui'
+import React from 'react'
+import styles from './category-combo-table.module.css'
+
+export const PaddingCell = () => (
+    <TableCell className={styles.paddingCell}></TableCell>
+)
+
+export default PaddingCell

--- a/src/data-workspace/category-combo-table/total-cells.js
+++ b/src/data-workspace/category-combo-table/total-cells.js
@@ -15,7 +15,7 @@ TotalCell.propTypes = {
 }
 
 export const TotalHeader = ({ rowSpan }) => (
-    <TableCellHead className={styles.totalHeader} rowSpan={rowSpan}>
+    <TableCellHead className={styles.totalHeader} rowSpan={rowSpan.toString()}>
         {i18n.t('Totals')}
     </TableCellHead>
 )

--- a/src/data-workspace/category-combo-table/total-cells.js
+++ b/src/data-workspace/category-combo-table/total-cells.js
@@ -42,7 +42,7 @@ RowTotal.propTypes = {
 
 export const ColumnTotals = ({
     renderTotalSum,
-    paddedCells,
+    paddingCells,
     dataElements,
     categoryOptionCombos,
 }) => {
@@ -57,7 +57,7 @@ export const ColumnTotals = ({
             {columnTotals.map((v, i) => (
                 <TotalCell key={i}>{v}</TotalCell>
             ))}
-            {paddedCells.map((_, i) => (
+            {paddingCells.map((_, i) => (
                 <TotalCell key={i} />
             ))}
             {renderTotalSum && (
@@ -72,6 +72,6 @@ export const ColumnTotals = ({
 ColumnTotals.propTypes = {
     categoryOptionCombos: propTypes.array,
     dataElements: propTypes.array,
-    paddedCells: propTypes.array,
+    paddingCells: propTypes.array,
     renderTotalSum: propTypes.bool,
 }

--- a/src/data-workspace/data-entry-cell/entry-field-input.js
+++ b/src/data-workspace/data-entry-cell/entry-field-input.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import { useRightHandPanelContext } from '../../right-hand-panel/index.js'
-import { useCurrentItemContext } from '../../shared/index.js'
+import { useSetCurrentItemContext } from '../../shared/index.js'
 import { focusNext, focusPrev } from '../focus-utils/index.js'
 import {
     GenericInput,
@@ -85,7 +85,7 @@ export function EntryFieldInput({
     setSyncStatus,
     disabled,
 }) {
-    const currentItemContext = useCurrentItemContext()
+    const setCurrentItem = useSetCurrentItemContext()
     const rightHandPanel = useRightHandPanelContext()
     const { id: deId } = de
     const { id: cocId } = coc
@@ -113,7 +113,7 @@ export function EntryFieldInput({
     }
 
     const onFocus = () => {
-        currentItemContext.setItem(currentItem)
+        setCurrentItem(currentItem)
         rightHandPanel.hide()
     }
 

--- a/src/data-workspace/section-form/section.js
+++ b/src/data-workspace/section-form/section.js
@@ -37,11 +37,16 @@ export const SectionFormSection = ({
         ? selectors.getGroupedDataElementsByCatComboInOrder(data, dataElements)
         : selectors.getGroupedDataElementsByCatCombo(data, dataElements)
 
-    const maxColumnsInSection = Math.max(
-        ...groupedDataElements.map(
-            (grp) => grp.categoryCombo.categoryOptionCombos?.length || 1
-        )
+    // calculate how many columns in each group
+    const groupedTotalColumns = groupedDataElements.map((grp) =>
+        (
+            selectors
+                .getCategoriesByCategoryComboId(data, grp.categoryCombo.id)
+                ?.map((cat) => cat.categoryOptions.length) || [1]
+        ).reduce((total, curr) => total * curr)
     )
+
+    const maxColumnsInSection = Math.max(...groupedTotalColumns)
 
     const greyedFields = new Set(
         section.greyedFields.map((greyedField) =>

--- a/src/shared/current-item-provider/current-item-context.js
+++ b/src/shared/current-item-provider/current-item-context.js
@@ -1,10 +1,12 @@
 import { createContext } from 'react'
 
-const CurrentItemContext = createContext({
+export const CurrentItemContext = createContext({
     item: null,
     setItem: () => {
         throw new Error('Current item context has not been initialized yet')
     },
 })
 
-export default CurrentItemContext
+export const SetCurrentItemContext = createContext(() => {
+    throw new Error('Current item context has not been initialized yet')
+})

--- a/src/shared/current-item-provider/current-item-provider.js
+++ b/src/shared/current-item-provider/current-item-provider.js
@@ -1,6 +1,9 @@
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
-import CurrentItemContext from './current-item-context.js'
+import {
+    CurrentItemContext,
+    SetCurrentItemContext,
+} from './current-item-context.js'
 
 export default function CurrentItemProvider({ children }) {
     const [item, setItem] = useState(null)
@@ -8,7 +11,9 @@ export default function CurrentItemProvider({ children }) {
 
     return (
         <CurrentItemContext.Provider value={value}>
-            {children}
+            <SetCurrentItemContext.Provider value={setItem}>
+                {children}
+            </SetCurrentItemContext.Provider>
         </CurrentItemContext.Provider>
     )
 }

--- a/src/shared/current-item-provider/index.js
+++ b/src/shared/current-item-provider/index.js
@@ -1,2 +1,2 @@
-export { default as useCurrentItemContext } from './use-current-item-context.js'
+export * from './use-current-item-context.js'
 export { default as CurrentItemProvider } from './current-item-provider.js'

--- a/src/shared/current-item-provider/use-current-item-context.js
+++ b/src/shared/current-item-provider/use-current-item-context.js
@@ -1,6 +1,13 @@
 import { useContext } from 'react'
-import CurrentItemContext from './current-item-context.js'
+import {
+    CurrentItemContext,
+    SetCurrentItemContext,
+} from './current-item-context.js'
 
-export default function useCurrentItemContext() {
+export function useCurrentItemContext() {
     return useContext(CurrentItemContext)
+}
+
+export function useSetCurrentItemContext() {
+    return useContext(SetCurrentItemContext)
 }


### PR DESCRIPTION
Refactors the header in to a separate component. This PR is meant to make the `CategoryComboTable`-component a bit easier to reason about, as well as solve some re-renders.

- useActiveCell caused entire table to re-render
   - This is now only re-renders header-component and DataElementCell (header of the data-element)
- CurrentItemContext caused all cells to re-render because they subscribed to this context
   - Splitting this to a separate "setter"-context, solves this, as the cells only need to set the item

