### PR TITLE
fix: update optionSet for metadata-api

### DIFF
--- a/src/data-workspace/data-entry-cell/entry-field-input.js
+++ b/src/data-workspace/data-entry-cell/entry-field-input.js
@@ -40,7 +40,7 @@ function createCurrentItem({ de, coc, dataValueSet }) {
 
 function InputComponent({ sharedProps, de }) {
     // If this is an option set, return OptionSet component
-    if (de.optionSetValue) {
+    if (de.optionSet) {
         return <OptionSet {...sharedProps} optionSetId={de.optionSet.id} />
     }
 

--- a/src/data-workspace/inputs/option-set.js
+++ b/src/data-workspace/inputs/option-set.js
@@ -72,11 +72,11 @@ export const OptionSet = ({
                     onBlur={() => input.onBlur()}
                     disabled={disabled}
                 >
-                    {options.map(({ name }) => (
+                    {options.map(({ id, displayName }) => (
                         <SingleSelectOption
-                            key={name}
-                            label={name}
-                            value={name}
+                            key={id}
+                            label={displayName}
+                            value={id}
                         />
                     ))}
                 </SingleSelect>

--- a/src/data-workspace/inputs/option-set.js
+++ b/src/data-workspace/inputs/option-set.js
@@ -72,11 +72,11 @@ export const OptionSet = ({
                     onBlur={() => input.onBlur()}
                     disabled={disabled}
                 >
-                    {options.map(({ id, displayName }) => (
+                    {options.map(({ id, code, displayName }) => (
                         <SingleSelectOption
                             key={id}
                             label={displayName}
-                            value={id}
+                            value={code}
                         />
                     ))}
                 </SingleSelect>


### PR DESCRIPTION
Note that it seems the old implementation used the wrong `value` for the selected optionSet. From looking at the request from the old `Data Entry`-app, it seems that the `code` is used for the value. This also makes sense, since the user are not allowed to change the `code` after an `option` is created. 


