### PR TITLE
refactor: move sortedcocs-computation to selector

### DIFF
--- a/src/data-workspace/category-combo-table-body/category-combo-table-body.js
+++ b/src/data-workspace/category-combo-table-body/category-combo-table-body.js
@@ -1,8 +1,7 @@
 import { TableBody, TableRow, TableCell } from '@dhis2/ui'
 import PropTypes from 'prop-types'
-import React, { useMemo, useCallback } from 'react'
+import React, { useCallback } from 'react'
 import { useMetadata, selectors } from '../../metadata/index.js'
-import { cartesian } from '../../shared/utils.js'
 import { DataEntryCell, DataEntryField } from '../data-entry-cell/index.js'
 import { getFieldId } from '../get-field-id.js'
 import { TableBodyHiddenByFiltersRow } from '../table-body-hidden-by-filter-row.js'
@@ -28,23 +27,10 @@ export const CategoryComboTableBody = ({
         categoryCombo.id
     )
 
-    const sortedCOCs = useMemo(() => {
-        // each element is a combination of category-options for a particular column
-        // this results in lists of category-options in the same order as headers are rendered
-        // the result is a client side computation of categoryOption-combinations
-        const optionsIdLists = categories.map((cat) => cat.categoryOptions)
-        const computedCategoryOptions = cartesian(optionsIdLists)
-        // find categoryOptionCombos by category-options
-        return computedCategoryOptions
-            .map((options) =>
-                selectors.getCoCByCategoryOptions(
-                    metadata,
-                    categoryCombo.id,
-                    options
-                )
-            )
-            .filter((coc) => !!coc)
-    }, [metadata, categories, categoryCombo])
+    const sortedCOCs = selectors.getSortedCoCsByCatComboId(
+        metadata,
+        categoryCombo.id
+    )
 
     if (sortedCOCs.length !== categoryCombo.categoryOptionCombos?.length) {
         console.warn(

--- a/src/metadata/selectors.js
+++ b/src/metadata/selectors.js
@@ -342,6 +342,7 @@ export const getCoCByCategoryOptions = createCachedSelector(
 /**
  * @param {*} metadata
  * @param {*} categoryComboId
+ * @returns {Array.<Array.<string>>} An array with arrays of categoryOption-ids
  */
 export const getComputedCategoryOptionsByCatComboId = createCachedSelector(
     getCategoriesByCategoryComboId,

--- a/src/metadata/selectors.js
+++ b/src/metadata/selectors.js
@@ -1,7 +1,7 @@
 import { createCachedSelector } from 're-reselect'
 import { createSelector } from 'reselect'
 import { parsePeriodId } from '../shared/index.js'
-
+import { cartesian } from '../shared/utils.js'
 // Helper to group array items by an identifier
 
 const groupBy = (input, getIdentifier) =>
@@ -337,6 +337,28 @@ export const getCoCByCategoryOptions = createCachedSelector(
 
         return null
     }
+)((_, categoryComboId) => categoryComboId)
+
+export const getComputedCategoryOptionsByCatComboId = createCachedSelector(
+    getCategoriesByCategoryComboId,
+    (categories) => {
+        const optionsIdLists = categories.map((cat) => cat.categoryOptions)
+        return cartesian(optionsIdLists)
+    }
+)((_, categoryComboId) => categoryComboId)
+
+/**
+ * @param {*} metadata
+ * @param {*} categoryComboId
+ */
+export const getSortedCoCsByCatComboId = createCachedSelector(
+    (metadata) => metadata,
+    (_, categoryComboId) => categoryComboId,
+    getComputedCategoryOptionsByCatComboId,
+    (metadata, categoryComboId, computedCOCS) =>
+        computedCOCS.map((options) =>
+            getCoCByCategoryOptions(metadata, categoryComboId, options)
+        )
 )((_, categoryComboId) => categoryComboId)
 
 const isOptionWithinPeriod = ({

--- a/src/metadata/selectors.js
+++ b/src/metadata/selectors.js
@@ -339,6 +339,10 @@ export const getCoCByCategoryOptions = createCachedSelector(
     }
 )((_, categoryComboId) => categoryComboId)
 
+/**
+ * @param {*} metadata
+ * @param {*} categoryComboId
+ */
 export const getComputedCategoryOptionsByCatComboId = createCachedSelector(
     getCategoriesByCategoryComboId,
     (categories) => {


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/TECH-1112 by refactoring the computation to a `cachedSelector`. 

This also moves the `cartesian`-computation to a selector, and thus the options will be stable between components and remounts. So this will only be recomputed once for every `categoryCombo`. Even if that `catComboTable` is unmounted and remounted again. 