### PR TITLE
refactor(app wrapper): improve jest test utils

### DIFF
--- a/src/app/app-wrapper.js
+++ b/src/app/app-wrapper.js
@@ -1,7 +1,8 @@
 import { CssReset, CssVariables } from '@dhis2/ui'
+import PropTypes from 'prop-types'
 import React from 'react'
-import { QueryClientProvider } from 'react-query'
-import { HashRouter as Router, Route } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from 'react-query'
+import { HashRouter, Route } from 'react-router-dom'
 import { QueryParamProvider } from 'use-query-params'
 import PrintAreaProvider from '../data-workspace/print-area/print-area-provider.js'
 import { RightHandPanelProvider } from '../right-hand-panel/index.js'
@@ -9,9 +10,25 @@ import { CurrentItemProvider } from '../shared/index.js'
 import App from './app.js'
 import useQueryClient from './query-client/use-query-client.js'
 
-const AppWrapper = () => {
-    const queryClient = useQueryClient()
-
+/**
+ * @param {Object} props
+ * @param {QueryClient} props.queryClient
+ * @param {*} props.children
+ * @param {Function} props.router
+ * This way we can use a different router in tests in conjunction with the
+ * original render function of @testing-library/react when needed, e.g:
+ *     router={({ children }) => (
+ *         <MemoryRouter initialEntries={['?dataSet=...&...']}>
+ *             {children}
+ *         </MemoryRouter>
+ *     )}
+ */
+export function OuterComponents({
+    queryClient,
+    children,
+    // This way we can use a different router in tests when needed
+    router: Router,
+}) {
     return (
         <>
             <CssReset />
@@ -22,7 +39,7 @@ const AppWrapper = () => {
                         <CurrentItemProvider>
                             <RightHandPanelProvider>
                                 <PrintAreaProvider>
-                                    <App />
+                                    {children}
                                 </PrintAreaProvider>
                             </RightHandPanelProvider>
                         </CurrentItemProvider>
@@ -33,4 +50,24 @@ const AppWrapper = () => {
     )
 }
 
-export default AppWrapper
+OuterComponents.defaultProps = {
+    router: HashRouter,
+}
+
+OuterComponents.propTypes = {
+    children: PropTypes.any.isRequired,
+    queryClient: PropTypes.instanceOf(QueryClient).isRequired,
+    // in js classes are functions, too
+    router: PropTypes.elementType,
+}
+
+// Must be default export as this is the component point to by "d2.config.js"
+export default function AppWrapper() {
+    const queryClient = useQueryClient()
+
+    return (
+        <OuterComponents queryClient={queryClient}>
+            <App />
+        </OuterComponents>
+    )
+}

--- a/src/app/app.test.js
+++ b/src/app/app.test.js
@@ -1,26 +1,9 @@
-import { DataProvider } from '@dhis2/app-runtime'
 import React from 'react'
-import ReactDOM from 'react-dom'
-import { QueryClient, QueryClientProvider } from 'react-query'
-import { CurrentItemProvider } from '../shared/index.js'
+import { render } from '../test-utils/index.js'
 import App from './app.js'
-
-const queryClient = new QueryClient()
 
 describe('<App />', () => {
     it('renders without crashing', () => {
-        const div = document.createElement('div')
-
-        ReactDOM.render(
-            <DataProvider>
-                <QueryClientProvider client={queryClient}>
-                    <CurrentItemProvider>
-                        <App />
-                    </CurrentItemProvider>
-                </QueryClientProvider>
-            </DataProvider>,
-            div
-        )
-        ReactDOM.unmountComponentAtNode(div)
+        render(<App />)
     })
 })

--- a/src/app/auth/auth-wall.test.js
+++ b/src/app/auth/auth-wall.test.js
@@ -1,5 +1,5 @@
-import { render } from '@testing-library/react'
 import React from 'react'
+import { render } from '../../test-utils/index.js'
 import AuthWall from './auth-wall.js'
 
 describe('<AuthWall />', () => {

--- a/src/app/layout/layout.test.js
+++ b/src/app/layout/layout.test.js
@@ -1,5 +1,5 @@
-import { render } from '@testing-library/react'
 import React from 'react'
+import { render } from '../../test-utils/index.js'
 import Layout from './layout.js'
 
 describe('<Layout />', () => {

--- a/src/data-workspace/data-details-sidebar/audit-log.test.js
+++ b/src/data-workspace/data-details-sidebar/audit-log.test.js
@@ -1,7 +1,8 @@
 import { CustomDataProvider } from '@dhis2/app-runtime'
-import { render, waitFor } from '@testing-library/react'
+import { waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
+import { render } from '../../test-utils/index.js'
 import AuditLog from './audit-log.js'
 
 describe('<AuditLog />', () => {

--- a/src/data-workspace/data-details-sidebar/basic-information.test.js
+++ b/src/data-workspace/data-details-sidebar/basic-information.test.js
@@ -1,6 +1,6 @@
-import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
+import { render } from '../../test-utils/index.js'
 import BasicInformation from './basic-information.js'
 
 const noop = () => {}

--- a/src/data-workspace/data-details-sidebar/comment.test.js
+++ b/src/data-workspace/data-details-sidebar/comment.test.js
@@ -1,6 +1,6 @@
 import { CustomDataProvider } from '@dhis2/app-runtime'
-import { render } from '@testing-library/react'
 import React from 'react'
+import { render } from '../../test-utils/index.js'
 import Comment from './comment.js'
 
 describe('<Comment />', () => {

--- a/src/data-workspace/data-details-sidebar/limits.test.js
+++ b/src/data-workspace/data-details-sidebar/limits.test.js
@@ -1,7 +1,8 @@
 import { CustomDataProvider } from '@dhis2/app-runtime'
-import { render, waitFor } from '@testing-library/react'
+import { waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
+import { render } from '../../test-utils/index.js'
 import Limits from './limits.js'
 
 describe('<Limits />', () => {

--- a/src/shared/sidebar/title.test.js
+++ b/src/shared/sidebar/title.test.js
@@ -1,6 +1,6 @@
-import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
+import { render } from '../../test-utils/index.js'
 import Title from './title.js'
 
 describe('<Title />', () => {

--- a/src/test-utils/index.js
+++ b/src/test-utils/index.js
@@ -1,0 +1,3 @@
+export { expectRenderError } from './expect-render-error.js'
+export { default as QueryClientWrapper } from './query-client-wrapper.js'
+export { render, TestWrapper } from './render.js'

--- a/src/test-utils/render.js
+++ b/src/test-utils/render.js
@@ -1,0 +1,38 @@
+/* eslint-disable react/prop-types */
+import { render as renderOrig } from '@testing-library/react'
+import React from 'react'
+import { QueryClient } from 'react-query'
+import { MemoryRouter } from 'react-router-dom'
+import { OuterComponents } from '../app/app-wrapper.js'
+
+export function TestWrapper({
+    wrapper: WrapperFromOptions,
+    router = MemoryRouter,
+    queryClient,
+    children,
+}) {
+    const content = (
+        <OuterComponents queryClient={queryClient} router={router}>
+            {children}
+        </OuterComponents>
+    )
+
+    if (!WrapperFromOptions) {
+        return content
+    }
+
+    return <WrapperFromOptions>{content}</WrapperFromOptions>
+}
+
+export function render(ui, options = {}) {
+    const queryClient = new QueryClient()
+
+    return renderOrig(ui, {
+        ...options,
+        wrapper: ({ children }) => (
+            <TestWrapper wrapper={options.wrapper} queryClient={queryClient}>
+                {children}
+            </TestWrapper>
+        ),
+    })
+}


### PR DESCRIPTION
I'm working on updating tests in #73. For this I need the components to be wrapped with the providers that wrapp the app component. @kabaros also had a similar need and ended up with a [`withAppTestWrapper`](https://github.com/dhis2/data-entry-app/blob/19a73e3637/src/test-utils/with-app-test-wrapper.js) HOC.

I already made a comment that I think I'd prefer the [official way](https://testing-library.com/docs/react-testing-library/setup/#custom-render) of doing this, so I created this PR which
* should support @kabaros's case (overriding the Router with `MemoryRouter`)
* exports the `TestWrapper` component as an escape hatch in case tests need to do something special
* updates all existing tests, showing that the changes just work

See [`src/app/app.test.js`](https://github.com/dhis2/data-entry-app/pull/99/files#diff-e7cb7ff6e3b917804d472df26e224c232bea4a09ad1f60500da1757a588a5e49) for how this removes test boilder plate code