### PR TITLE
fix(validation): tweaks for validation right hand panel

### DIFF
--- a/src/bottom-bar/main-tool-bar.js
+++ b/src/bottom-bar/main-tool-bar.js
@@ -21,7 +21,11 @@ export default function MainToolBar() {
     const complete = () => console.log('@TODO(complete): implement me!')
     const incomplete = () => console.log('@TODO(incomplete): implement me!')
     const validate = () => {
-        rightHandPanel.show(validationResultsSidebarId)
+        if (rightHandPanel.id === validationResultsSidebarId) {
+            rightHandPanel.hide()
+        } else {
+            rightHandPanel.show(validationResultsSidebarId)
+        }
     }
     const completedBy = 'Firstname Lastname' // @TODO(completedBy): implement me!
 

--- a/src/data-workspace/entry-form.js
+++ b/src/data-workspace/entry-form.js
@@ -7,7 +7,6 @@ import { CustomForm } from './custom-form/index.js'
 import { DefaultForm } from './default-form.js'
 import FilterField from './filter-field.js'
 import { SectionForm } from './section-form/index.js'
-import useCloseRightHandPanelOnSelectionChange from './use-close-right-hand-panel-on-selection-change.js'
 const formTypeToComponent = {
     DEFAULT: DefaultForm,
     SECTION: SectionForm,
@@ -32,8 +31,6 @@ export const EntryForm = React.memo(function EntryForm({ dataSet }) {
     })
 
     const Component = formTypeToComponent[formType]
-
-    useCloseRightHandPanelOnSelectionChange()
 
     return (
         <>

--- a/src/data-workspace/use-close-right-hand-panel-on-selection-change.js
+++ b/src/data-workspace/use-close-right-hand-panel-on-selection-change.js
@@ -1,18 +1,20 @@
 import { useEffect } from 'react'
-import { useParams } from 'react-router-dom'
+import {
+    useAttributeOptionComboSelection,
+    useDataSetId,
+    useOrgUnitId,
+    usePeriodId,
+} from '../context-selection/index.js'
 import { useRightHandPanelContext } from '../right-hand-panel/index.js'
 
 export default function useCloseRightHandPanelOnSelectionChange() {
-    const { show } = useRightHandPanelContext()
-    const searchParams = useParams()
+    const { hide } = useRightHandPanelContext()
+    const [dataSetId] = useDataSetId()
+    const [periodId] = usePeriodId()
+    const [orgUnitId] = useOrgUnitId()
+    const [attributeOptionComboSelection] = useAttributeOptionComboSelection()
 
-    useEffect(
-        () => {
-            show('')
-        },
-        // search params are part of the dependency array as we need to hide
-        // the sidebar when the selection changes. There's no need to use the
-        // search params in the useEffect though
-        [searchParams, show]
-    )
+    useEffect(() => {
+        hide()
+    }, [dataSetId, periodId, orgUnitId, attributeOptionComboSelection, hide])
 }

--- a/src/right-hand-panel/right-hand-panel.js
+++ b/src/right-hand-panel/right-hand-panel.js
@@ -6,6 +6,7 @@ import {
     validationResultsSidebarId,
 } from '../data-workspace/constants.js'
 import { DataDetailsSidebar } from '../data-workspace/index.js'
+import useCloseRightHandPanelOnSelectionChange from '../data-workspace/use-close-right-hand-panel-on-selection-change.js'
 import ValidationResultsSidebar from '../data-workspace/validation/validation-results-sidebar.js'
 import styles from './right-hand-panel.module.css'
 import useRightHandPanelContext from './use-right-hand-panel-context.js'
@@ -18,6 +19,8 @@ const idSidebarMap = {
 
 export default function RightHandPanel() {
     const { id, show, hide } = useRightHandPanelContext()
+    useCloseRightHandPanelOnSelectionChange()
+
     const SidebarComponent = idSidebarMap[id]
 
     if (id && !SidebarComponent) {


### PR DESCRIPTION
## Changes in this PR

- When the right hand panel is open, and the "Run Validation" button in the bottom bar is clicked, then the the panel is toggled closed
- Ensure that the right panel is hidden when the dataset changes
- Get rid of `0` that appeared in comments validation section when no violations exist

## Screenshots

**Closing right hand panel when dataset is changed**
| Before | After
| --- | --- |
|  ![close_right_hand_on_change_dataset_before](https://user-images.githubusercontent.com/1014725/182303918-27817f0c-7866-47dd-ab91-81a7f88e3ef7.gif) | ![close_right_hand_on_change_dataset_after](https://user-images.githubusercontent.com/1014725/182303929-3b20eade-7dc9-4ffc-81c1-ea4ee48de3ab.gif) |

**Clicking Run validation in the bottom menu again closes an already open menu**
| Before | After
| --- | --- |
| ![toggle_right_hand_before](https://user-images.githubusercontent.com/1014725/182304199-45dac5b9-a388-4bb0-a3b8-9b8e04b252a3.gif) |  ![toggle_right_hand_after](https://user-images.githubusercontent.com/1014725/182304211-a825644d-d9c6-4b76-8c4a-292f2d8107bf.gif) |