### PR TITLE
fix: show empty string when indicator value cannot be computed

### DIFF
--- a/src/data-workspace/indicators-table-body/compute-indicator-value.js
+++ b/src/data-workspace/indicators-table-body/compute-indicator-value.js
@@ -118,5 +118,5 @@ export const computeIndicatorValue = ({
     const indicatorValue = (numeratorValue / denominatorValue) * factor
     const isReadableNumber = isFinite(indicatorValue) && !isNaN(indicatorValue)
 
-    return isReadableNumber ? indicatorValue : '-'
+    return isReadableNumber ? indicatorValue : ''
 }

--- a/src/data-workspace/indicators-table-body/compute-indicator-value.test.js
+++ b/src/data-workspace/indicators-table-body/compute-indicator-value.test.js
@@ -49,4 +49,22 @@ describe('computeIndicatorValue', () => {
         })
         expect(value).toBe((9 / 15) * 100)
     })
+    it('returns an empty string when computed value would be NaN', () => {
+        const value = computeIndicatorValue({
+            numerator: '#{nothing}',
+            denominator: '#{nothing_also}',
+            factor: 1,
+            formState,
+        })
+        expect(value).toBe('')
+    })
+    it('returns an empty string when computed value would be Infinity', () => {
+        const value = computeIndicatorValue({
+            numerator: '#{a}+#{b.b1}*#{c.c1}', // 3+2*3=9
+            denominator: '#{nothing}',
+            factor: 1,
+            formState,
+        })
+        expect(value).toBe('')
+    })
 })


### PR DESCRIPTION
The old app used to show `'-'`, but the new app should show nothing.