### PR TITLE
fix(aoc selector): implement openPeriodsAfterCoEndDate

### DIFF
--- a/src/shared/metadata/selectors.test.js
+++ b/src/shared/metadata/selectors.test.js
@@ -10,6 +10,7 @@ import {
     getCategoryOptions,
     getCategoryOptionsByCategoryId,
     getCategoryOptionsByCategoryOptionComboId,
+    getCategoriesWithOptionsWithinPeriod,
     getCoCByCategoryOptions,
     getDataElements,
     getDataElementsByDataSetId,
@@ -758,5 +759,195 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
         )
 
         expect(actual).toEqual(expected)
+    })
+
+    describe('getCategoriesWithOptionsWithinPeriod', () => {
+        it('should return all category options if none have end dates', () => {
+            const datasetid = 'dataset-id-1a'
+            const periodid = '202201'
+
+            const catcomboid = 'categorycombo-id-1'
+
+            const metadata = {
+                dataSets: {
+                    [datasetid]: {
+                        categoryCombo: { id: catcomboid },
+                        periodType: 'Monthly',
+                        id: datasetid,
+                    },
+                },
+                categoryCombos: {
+                    [catcomboid]: {
+                        id: catcomboid,
+                        categories: ['co-id-letter', 'co-id-number'],
+                    },
+                },
+                categories: {
+                    'co-id-letter': {
+                        id: 'co-id-letter',
+                        categoryOptions: ['cat-id-a', 'cat-id-b', 'cat-id-c'],
+                    },
+                    'co-id-number': {
+                        id: 'co-id-number',
+                        categoryOptions: ['cat-id-1', 'cat-id-2'],
+                    },
+                },
+                categoryOptions: {
+                    'cat-id-a': { id: 'cat-id-a' },
+                    'cat-id-b': { id: 'cat-id-b' },
+                    'cat-id-c': { id: 'cat-id-c' },
+                    'cat-id-1': { id: 'cat-id-1' },
+                    'cat-id-2': { id: 'cat-id-2' },
+                },
+            }
+
+            const expected = [
+                {
+                    categoryOptions: [
+                        { id: 'cat-id-a' },
+                        { id: 'cat-id-b' },
+                        { id: 'cat-id-c' },
+                    ],
+                    id: 'co-id-letter',
+                },
+                {
+                    categoryOptions: [{ id: 'cat-id-1' }, { id: 'cat-id-2' }],
+                    id: 'co-id-number',
+                },
+            ]
+
+            const actual = getCategoriesWithOptionsWithinPeriod(
+                metadata,
+                datasetid,
+                periodid
+            )
+
+            expect(actual).toEqual(expected)
+        })
+
+        it('should return category options without endDate or with endDate after period end ', () => {
+            const datasetid = 'dataset-id-1a'
+            const periodid = '202201'
+
+            const catcomboid = 'categorycombo-id-1'
+
+            const metadata = {
+                dataSets: {
+                    [datasetid]: {
+                        categoryCombo: { id: catcomboid },
+                        periodType: 'Monthly',
+                        id: datasetid,
+                    },
+                },
+                categoryCombos: {
+                    [catcomboid]: {
+                        id: catcomboid,
+                        categories: ['co-id-letter', 'co-id-number'],
+                    },
+                },
+                categories: {
+                    'co-id-letter': {
+                        id: 'co-id-letter',
+                        categoryOptions: ['cat-id-a', 'cat-id-b', 'cat-id-c'],
+                    },
+                    'co-id-number': {
+                        id: 'co-id-number',
+                        categoryOptions: ['cat-id-1', 'cat-id-2'],
+                    },
+                },
+                categoryOptions: {
+                    'cat-id-a': { id: 'cat-id-a', endDate: '2020-01-01' },
+                    'cat-id-b': { id: 'cat-id-b', endDate: '2022-01-01' },
+                    'cat-id-c': { id: 'cat-id-c' },
+                    'cat-id-1': { id: 'cat-id-1', endDate: '2022-09-01' },
+                    'cat-id-2': { id: 'cat-id-2' },
+                },
+            }
+
+            const expected = [
+                { categoryOptions: [{ id: 'cat-id-c' }], id: 'co-id-letter' },
+                {
+                    categoryOptions: [
+                        { id: 'cat-id-1', endDate: '2022-09-01' },
+                        { id: 'cat-id-2' },
+                    ],
+                    id: 'co-id-number',
+                },
+            ]
+
+            const actual = getCategoriesWithOptionsWithinPeriod(
+                metadata,
+                datasetid,
+                periodid
+            )
+
+            expect(actual).toEqual(expected)
+        })
+
+        it('should return category options without endDate or with endDate after period end, adjusting for openPeriodsAfterCoEndDate', () => {
+            const datasetid = 'dataset-id-1a'
+            const periodid = '202201'
+
+            const catcomboid = 'categorycombo-id-1'
+
+            const metadata = {
+                dataSets: {
+                    [datasetid]: {
+                        categoryCombo: { id: catcomboid },
+                        periodType: 'Monthly',
+                        id: datasetid,
+                        openPeriodsAfterCoEndDate: 2,
+                    },
+                },
+                categoryCombos: {
+                    [catcomboid]: {
+                        id: catcomboid,
+                        categories: ['co-id-letter', 'co-id-number'],
+                    },
+                },
+                categories: {
+                    'co-id-letter': {
+                        id: 'co-id-letter',
+                        categoryOptions: ['cat-id-a', 'cat-id-b', 'cat-id-c'],
+                    },
+                    'co-id-number': {
+                        id: 'co-id-number',
+                        categoryOptions: ['cat-id-1', 'cat-id-2'],
+                    },
+                },
+                categoryOptions: {
+                    'cat-id-a': { id: 'cat-id-a', endDate: '2020-01-01' },
+                    'cat-id-b': { id: 'cat-id-b', endDate: '2022-01-01' },
+                    'cat-id-c': { id: 'cat-id-c' },
+                    'cat-id-1': { id: 'cat-id-1', endDate: '2022-09-01' },
+                    'cat-id-2': { id: 'cat-id-2' },
+                },
+            }
+
+            const expected = [
+                {
+                    categoryOptions: [
+                        { id: 'cat-id-b', endDate: '2022-01-01' },
+                        { id: 'cat-id-c' },
+                    ],
+                    id: 'co-id-letter',
+                },
+                {
+                    categoryOptions: [
+                        { id: 'cat-id-1', endDate: '2022-09-01' },
+                        { id: 'cat-id-2' },
+                    ],
+                    id: 'co-id-number',
+                },
+            ]
+
+            const actual = getCategoriesWithOptionsWithinPeriod(
+                metadata,
+                datasetid,
+                periodid
+            )
+
+            expect(actual).toEqual(expected)
+        })
     })
 })


### PR DESCRIPTION
This implements logic for `openPeriodsAfterCoEndDate` which "extends" the endDate of the categoryOption by the number of periods specified by `openPeriodsAfterCoEndDate` (e.g. if categoryOption should expire on `2022-01-15`, but it's being used on a Monthly dataset with `openPeriodsAfterCoEndDate:3`, the categoryOption would effectively expire on `2022-04-15` for the purposes of data entry on that data set)

The logic check for categoryOption already existed in the code (https://github.com/dhis2/data-entry-app/blob/development/src/shared/metadata/selectors.js#L394): `periodEndDate > endDate`, which I have adapted to accommodate for `openPeriodsAfterCoEndDate`

I initially extended the endDate's of the individual categoryOptions, but I switched in the version I am submitting to instead reduce the dataset's periodEndDate. This seems a little less logically intuitive than extending individual categoryOptions' endDates, but it should be mathematically equivalent (i.e. `periodEndDate > (endDate + X periods)` = `(periodEndDate - X periods) > endDate`. I thought this approach was ultimately better because:

- if there are a lot of categoryOptions with endDates, this saves calculation time because we only do the adjustment for `openPeriodsAfterCoEndDate` once on the periodEndDate rather than multiple times on each of the categoryOptions' endDates
- I think this could better avoid some peculiarities that could arise with regards to end of period categoryOption endDates (e.g. if we have a Monthly dataset and our categoryOption has endDate of `2021-04-30` and we extend it because  openPeriodsAfterCoEndDate:3, we get `2021-07-30` which is probably not what a user would want? Instead if we reduce the periodEndDate, if we are in 2021 July, we would get an updated periodEndDate of `2021-04-30` to compare against)