### PR TITLE
fix(min/max validators): allow entry of zero,decimals,negatives

### DIFF
--- a/src/data-workspace/data-details-sidebar/limits-form-wrapper.js
+++ b/src/data-workspace/data-details-sidebar/limits-form-wrapper.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { Form } from 'react-final-form'
 import { useOrgUnitId } from '../../shared/index.js'
-import { createLessThan, validatorsByValueTypeMinMax } from '../inputs/index.js'
+import { createLessThan, minMaxValidatorsByValueType } from '../inputs/index.js'
 import { useUpdateLimits } from '../min-max-limits-mutations/index.js'
 import limitInputLabelsByName from './limits-input-labels-by-name.js'
 
@@ -27,7 +27,7 @@ export default function LimitsFormWrapper({
             maxValue: parseFloat(max),
         })
 
-    const validator = validatorsByValueTypeMinMax[valueType]
+    const validator = minMaxValidatorsByValueType[valueType]
     const validateMin = composeValidators(
         (value, values) => {
             if (!value && !!values.max) {

--- a/src/data-workspace/data-details-sidebar/limits-form-wrapper.js
+++ b/src/data-workspace/data-details-sidebar/limits-form-wrapper.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { Form } from 'react-final-form'
 import { useOrgUnitId } from '../../shared/index.js'
-import { createLessThan, validatorsByValueType } from '../inputs/index.js'
+import { createLessThan, validatorsByValueTypeMinMax } from '../inputs/index.js'
 import { useUpdateLimits } from '../min-max-limits-mutations/index.js'
 import limitInputLabelsByName from './limits-input-labels-by-name.js'
 
@@ -23,11 +23,11 @@ export default function LimitsFormWrapper({
             categoryOptionCombo: categoryOptionComboId,
             dataElement: dataElementId,
             orgUnit: orgUnitId,
-            minValue: min,
-            maxValue: max,
+            minValue: parseFloat(min),
+            maxValue: parseFloat(max),
         })
 
-    const validator = validatorsByValueType[valueType]
+    const validator = validatorsByValueTypeMinMax[valueType]
     const validateMin = composeValidators(
         (value, values) => {
             if (!value && !!values.max) {

--- a/src/data-workspace/data-details-sidebar/update-limits.js
+++ b/src/data-workspace/data-details-sidebar/update-limits.js
@@ -23,13 +23,11 @@ function UpdateLimits({
 
     const minField = useField('min', {
         initialValue: limits.min,
-        parse: (value) => (value === '' ? '' : parseInt(value, 10)),
         format: (value) => (value ? value.toString() : ''),
     })
 
     const maxField = useField('max', {
         initialValue: limits.max,
-        parse: (value) => (value === '' ? '' : parseInt(value, 10)),
         format: (value) => (value ? value.toString() : ''),
     })
 
@@ -63,7 +61,15 @@ function UpdateLimits({
             <LimitsValidationErrorMessage errors={errors} />
 
             <ButtonStrip>
-                <Button small primary type="submit" loading={submitting}>
+                <Button
+                    small
+                    primary
+                    type="submit"
+                    loading={submitting}
+                    disabled={
+                        errors === undefined || Object.keys(errors).length !== 0
+                    }
+                >
                     {submitting ? i18n.t('Saving...') : i18n.t('Save limits')}
                 </Button>
 

--- a/src/data-workspace/data-details-sidebar/update-limits.js
+++ b/src/data-workspace/data-details-sidebar/update-limits.js
@@ -67,7 +67,7 @@ function UpdateLimits({
                     type="submit"
                     loading={submitting}
                     disabled={
-                        errors === undefined || Object.keys(errors).length !== 0
+                        errors !== undefined && Object.keys(errors).length !== 0
                     }
                 >
                     {submitting ? i18n.t('Saving...') : i18n.t('Save limits')}

--- a/src/data-workspace/data-details-sidebar/update-limits.js
+++ b/src/data-workspace/data-details-sidebar/update-limits.js
@@ -23,12 +23,12 @@ function UpdateLimits({
 
     const minField = useField('min', {
         initialValue: limits.min,
-        format: (value) => (value ? value.toString() : ''),
+        format: (value) => (value !== undefined ? value.toString() : ''),
     })
 
     const maxField = useField('max', {
         initialValue: limits.max,
-        format: (value) => (value ? value.toString() : ''),
+        format: (value) => (value !== undefined ? value.toString() : ''),
     })
 
     const average = calculateAverage(minField.input.value, maxField.input.value)

--- a/src/data-workspace/inputs/index.js
+++ b/src/data-workspace/inputs/index.js
@@ -8,5 +8,5 @@ export {
     createLessThan,
     createMoreThan,
     validatorsByValueType,
-    validatorsByValueTypeMinMax,
+    minMaxValidatorsByValueType,
 } from './validators.js'

--- a/src/data-workspace/inputs/index.js
+++ b/src/data-workspace/inputs/index.js
@@ -8,4 +8,5 @@ export {
     createLessThan,
     createMoreThan,
     validatorsByValueType,
+    validatorsByValueTypeMinMax,
 } from './validators.js'

--- a/src/data-workspace/inputs/validators.js
+++ b/src/data-workspace/inputs/validators.js
@@ -81,10 +81,14 @@ export const validatorsByValueType = {
     [VALUE_TYPES.URL]: url,
 }
 
-// minimum and maximum values are restricted to integers
-export const validatorsByValueTypeMinMax = {
-    ...validatorsByValueType,
+export const minMaxValidatorsByValueType = {
+    [VALUE_TYPES.INTEGER]: integer,
+    [VALUE_TYPES.INTEGER_POSITIVE]: integerPositive,
+    [VALUE_TYPES.INTEGER_NEGATIVE]: integerNegative,
+    [VALUE_TYPES.INTEGER_ZERO_OR_POSITIVE]: integerZeroOrPositive,
+    // backend restricts minimum and maximum to integers
     [VALUE_TYPES.NUMBER]: integer,
+    [VALUE_TYPES.PERCENTAGE]: integerZeroOrPositive,
 }
 
 // This is an internal helper of the ui-forms library,

--- a/src/data-workspace/inputs/validators.js
+++ b/src/data-workspace/inputs/validators.js
@@ -81,6 +81,12 @@ export const validatorsByValueType = {
     [VALUE_TYPES.URL]: url,
 }
 
+// minimum and maximum values are restricted to integers
+export const validatorsByValueTypeMinMax = {
+    ...validatorsByValueType,
+    [VALUE_TYPES.NUMBER]: integer,
+}
+
 // This is an internal helper of the ui-forms library,
 // can be removed once `createLessThan` and `createMoreThan` have been moved to
 // the @dhis2/ui-forms library

--- a/src/data-workspace/inputs/validators.js
+++ b/src/data-workspace/inputs/validators.js
@@ -61,6 +61,12 @@ export const integerZeroOrPositive = composeValidators(
 export const integerNegative = composeValidators(integer, createMaxNumber(-1))
 
 export const percentage = createNumberRange(0, 100)
+const percentageInteger = composeValidators(
+    integer,
+    createMinNumber(0),
+    createMaxNumber(100)
+)
+
 export const unitInterval = createNumberRange(0, 1)
 
 export const validatorsByValueType = {
@@ -88,7 +94,7 @@ export const minMaxValidatorsByValueType = {
     [VALUE_TYPES.INTEGER_ZERO_OR_POSITIVE]: integerZeroOrPositive,
     // backend restricts minimum and maximum to integers
     [VALUE_TYPES.NUMBER]: integer,
-    [VALUE_TYPES.PERCENTAGE]: integerZeroOrPositive,
+    [VALUE_TYPES.PERCENTAGE]: percentageInteger,
 }
 
 // This is an internal helper of the ui-forms library,

--- a/src/data-workspace/inputs/validators.js
+++ b/src/data-workspace/inputs/validators.js
@@ -95,7 +95,9 @@ export const createLessThan = (key, description) => {
     )
 
     return (value, allValues) =>
-        isEmpty(value) || isEmpty(allValues[key]) || value < allValues[key]
+        isEmpty(value) ||
+        isEmpty(allValues[key]) ||
+        parseFloat(value) < parseFloat(allValues[key])
             ? undefined
             : errorMessage
 }

--- a/src/data-workspace/min-max-limits-mutations/use-delete-limits.js
+++ b/src/data-workspace/min-max-limits-mutations/use-delete-limits.js
@@ -47,7 +47,9 @@ export default function useDeleteLimits(onDone) {
     })
 
     const engine = useDataEngine()
-    const showErrorAlert = useAlert((message) => message, { critical: true })
+    const { show: showErrorAlert } = useAlert((message) => message, {
+        critical: true,
+    })
 
     const mutationFn = ({
         dataElement,

--- a/src/data-workspace/min-max-limits-mutations/use-update-limits.js
+++ b/src/data-workspace/min-max-limits-mutations/use-update-limits.js
@@ -47,7 +47,10 @@ export default function useUpdateLimits(onDone) {
     const dataValueSetQueryKey = useDataValueSetQueryKey()
 
     const engine = useDataEngine()
-    const showErrorAlert = useAlert((message) => message, { critical: true })
+
+    const { show: showErrorAlert } = useAlert((message) => message, {
+        critical: true,
+    })
 
     const mutationFn = ({
         dataElement,


### PR DESCRIPTION
This fixes the issue where zeros, negatives, decimal values could not be entered (even when valid): https://dhis2.atlassian.net/browse/TECH-1327

I noticed the save button was clickable when there were errors (but no post request was sent), so I have disabled it when there are errors