### PR TITLE
fix: data values duplicate request

### DIFF
--- a/src/app/query-client/configured-query-client-provider.js
+++ b/src/app/query-client/configured-query-client-provider.js
@@ -22,6 +22,8 @@ const persistOptions = {
         defaultOptions: {
             queries: {
                 meta: {
+                    // meta-property is not persisted, so this makes sure dehydrated-queries will
+                    // be persisted again
                     persist: true,
                     // can be used to check if the query originates from the persisted-store
                     isHydrated: true,

--- a/src/app/query-client/configured-query-client-provider.js
+++ b/src/app/query-client/configured-query-client-provider.js
@@ -18,6 +18,17 @@ const persistOptions = {
             return isSuccess && shouldPersist
         },
     },
+    hydrateOptions: {
+        defaultOptions: {
+            queries: {
+                meta: {
+                    persist: true,
+                    // can be used to check if the query originates from the persisted-store
+                    isHydrated: true,
+                },
+            },
+        },
+    },
 }
 
 export const ConfiguredQueryClientProvider = ({ children, queryClient }) => {

--- a/src/shared/highlighted-field/use-highlighted-field.js
+++ b/src/shared/highlighted-field/use-highlighted-field.js
@@ -49,10 +49,17 @@ export default function useHighlightedField() {
 
     useEffect(() => {
         const { de, coc } = item
-        setHighlightedFieldId(
-            gatherHighlightedFieldData({ de, coc, dataValueSet })
-        )
-    }, [item, dataValueSet])
+        // only update if it's different from currentItem
+        // prevents unnecessary re-render on first-render as well
+        if (
+            de.id !== currentItem?.dataElement ||
+            coc.id !== currentItem?.categoryOptionCombo
+        ) {
+            setHighlightedFieldId(
+                gatherHighlightedFieldData({ de, coc, dataValueSet })
+            )
+        }
+    }, [currentItem, item, dataValueSet])
 
     return currentItem
 }

--- a/src/shared/use-data-value-set/use-data-value-set.js
+++ b/src/shared/use-data-value-set/use-data-value-set.js
@@ -64,6 +64,13 @@ export const useDataValueSet = () => {
         // Only enable this query if there are no ongoing mutations
         enabled: isValidSelection,
         select,
+        refetchOnMount: (query) => {
+            // only refetch on mount if the query was just hydrated
+            // this should only when we first load the app.
+            // If we were to return 'false' the query would not be refetch on first mount
+            // because it's mounted with hydrated-state
+            return query.meta.isHydrated
+        },
         // Only fetch whilst offline, to prevent optimistic updates from being overwritten
         networkMode: 'online',
         meta,

--- a/src/shared/use-data-value-set/use-data-value-set.js
+++ b/src/shared/use-data-value-set/use-data-value-set.js
@@ -64,12 +64,13 @@ export const useDataValueSet = () => {
         // Only enable this query if there are no ongoing mutations
         enabled: isValidSelection,
         select,
+        //refetchOnMount: false,
         refetchOnMount: (query) => {
             // only refetch on mount if the query was just hydrated
             // this should only happen during initial app-load.
             // If we were to return 'false' the query would not be refetch on first mount
             // because it's mounted with hydrated-state
-            return query.meta.isHydrated
+            return !!query.meta.isHydrated
         },
         // Only fetch whilst offline, to prevent optimistic updates from being overwritten
         networkMode: 'online',

--- a/src/shared/use-data-value-set/use-data-value-set.js
+++ b/src/shared/use-data-value-set/use-data-value-set.js
@@ -66,7 +66,7 @@ export const useDataValueSet = () => {
         select,
         refetchOnMount: (query) => {
             // only refetch on mount if the query was just hydrated
-            // this should only when we first load the app.
+            // this should only happen during initial app-load.
             // If we were to return 'false' the query would not be refetch on first mount
             // because it's mounted with hydrated-state
             return query.meta.isHydrated


### PR DESCRIPTION
[TECH-1320](https://dhis2.atlassian.net/browse/TECH-1320)

This also fixes persisted queries. Previously, they would only be retrieved from  the cache "every other reload of the app", because the `meta`-property on the query was not persisted - so just hydrate queries would not be persisted again, due to lacking `meta.persist`. This should now be fixed by adding this property to all dehydrated queries. 