### PR TITLE
fix: restrict att opts by org unit

### DIFF
--- a/cypress/integration/context-selection/categories.feature
+++ b/cypress/integration/context-selection/categories.feature
@@ -31,5 +31,4 @@ Feature: Category options for each category in the category combination connecte
 
     Scenario: All options of one category are "out of bound"
         Given a data set, org unit & period have been selected and the current date is outside the range of all of the option's validity dates of one category
-        Then the attribute option combo selector is hidden
-        And a message is being displayed in the data workspace
+        Then a message is being displayed in the data workspace

--- a/cypress/integration/context-selection/categories/index.js
+++ b/cypress/integration/context-selection/categories/index.js
@@ -156,10 +156,6 @@ Then('the selector should show that some items have been selected', () => {
         .should('exist')
 })
 
-Then('the attribute option combo selector is hidden', () => {
-    cy.get('[data-test="attribute-option-combo-selector"]').should('not.exist')
-})
-
 Then('a message is being displayed in the data workspace', () => {
     cy.contains('The current selection does not have a form').should('exist')
 })

--- a/src/context-selection/attribute-option-combo-selector-bar-item/attribute-option-combo-selector-bar-item.js
+++ b/src/context-selection/attribute-option-combo-selector-bar-item/attribute-option-combo-selector-bar-item.js
@@ -18,17 +18,17 @@ import useShouldComponentRenderNull from './use-should-component-render-null.js'
 const hasCategoryNoOptions = (category) => category.categoryOptions.length === 0
 
 const useSetSelectionHasNoFormMessage = (
-    categoryWithNoOptionsExists,
+    categoriesWithNoOptions,
     setSelectionHasNoFormMessage
 ) => {
     useEffect(() => {
-        if (categoryWithNoOptionsExists?.length > 0) {
+        if (categoriesWithNoOptions?.length > 0) {
             setSelectionHasNoFormMessage(
                 i18n.t(
-                    'The following categories do not have valid options for the selected period or organisation unit: {{categories}}',
+                    'Some categories have no valid options for the selected period or organisation unit ({{categories}})',
                     {
-                        categories: categoryWithNoOptionsExists
-                            .map((category) => category?.displayName)
+                        categories: categoriesWithNoOptions
+                            .map((cat) => cat.displayName)
                             .join(', '),
                     }
                 )
@@ -36,9 +36,9 @@ const useSetSelectionHasNoFormMessage = (
         } else {
             setSelectionHasNoFormMessage('')
         }
-    }, [categoryWithNoOptionsExists, setSelectionHasNoFormMessage])
+    }, [categoriesWithNoOptions, setSelectionHasNoFormMessage])
 
-    return categoryWithNoOptionsExists
+    return categoriesWithNoOptions
 }
 
 export default function AttributeOptionComboSelectorBarItem({
@@ -53,7 +53,7 @@ export default function AttributeOptionComboSelectorBarItem({
         dataSetId
     )
     const relevantCategoriesWithOptions =
-        selectors.getCategoriesWithOptionsWithinPeriodForOrgUnit(
+        selectors.getCategoriesWithOptionsWithinPeriodWithOrgUnit(
             metadata,
             dataSetId,
             periodId,
@@ -70,13 +70,13 @@ export default function AttributeOptionComboSelectorBarItem({
             categoryId,
         })
 
-    const categoryWithNoOptionsExists =
+    const categoriesWithNoOptions =
         relevantCategoriesWithOptions.filter(hasCategoryNoOptions)
     const shouldComponentRenderNull =
         useShouldComponentRenderNull(categoryCombo)
 
     useSetSelectionHasNoFormMessage(
-        categoryWithNoOptionsExists,
+        categoriesWithNoOptions,
         setSelectionHasNoFormMessage
     )
 

--- a/src/context-selection/attribute-option-combo-selector-bar-item/categories-menu.js
+++ b/src/context-selection/attribute-option-combo-selector-bar-item/categories-menu.js
@@ -16,10 +16,7 @@ export default function CategoriesMenu({
     selected,
     onChange,
 }) {
-    if (
-        categories.length === 1 &&
-        categories[0]?.categoryOptions?.length !== 0
-    ) {
+    if (categories.length === 1 && categories[0].categoryOptions?.length > 0) {
         const category = categories[0]
         const values = category.categoryOptions.map(({ id, displayName }) => ({
             value: id,

--- a/src/context-selection/attribute-option-combo-selector-bar-item/categories-menu.js
+++ b/src/context-selection/attribute-option-combo-selector-bar-item/categories-menu.js
@@ -1,5 +1,10 @@
 import i18n from '@dhis2/d2-i18n'
-import { Button, SingleSelectField, SingleSelectOption } from '@dhis2/ui'
+import {
+    Button,
+    NoticeBox,
+    SingleSelectField,
+    SingleSelectOption,
+} from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { MenuSelect } from '../menu-select/index.js'
@@ -37,28 +42,41 @@ export default function CategoriesMenu({
     return (
         <div className={css.container}>
             <div className={css.inputs}>
-                {categories.map(({ id, displayName, categoryOptions }) => (
-                    <div className={css.input} key={id}>
-                        <SingleSelectField
-                            label={displayName}
-                            selected={selected[id]}
-                            onChange={({ selected }) =>
-                                onChange({
-                                    categoryId: id,
-                                    selected,
-                                })
-                            }
+                {categories.map(({ id, displayName, categoryOptions }) => {
+                    return categoryOptions.length === 0 ? (
+                        <NoticeBox
+                            className={css.noOptionsBox}
+                            error
+                            title={i18n.t('No available options')}
                         >
-                            {categoryOptions.map(({ id, displayName }) => (
-                                <SingleSelectOption
-                                    key={id}
-                                    value={id}
-                                    label={displayName}
-                                />
-                            ))}
-                        </SingleSelectField>
-                    </div>
-                ))}
+                            {i18n.t(
+                                `There are no options for {{categoryName}} for the selected period and organisation unit.`,
+                                { categoryName: displayName }
+                            )}
+                        </NoticeBox>
+                    ) : (
+                        <div className={css.input} key={id}>
+                            <SingleSelectField
+                                label={displayName}
+                                selected={selected[id]}
+                                onChange={({ selected }) =>
+                                    onChange({
+                                        categoryId: id,
+                                        selected,
+                                    })
+                                }
+                            >
+                                {categoryOptions.map(({ id, displayName }) => (
+                                    <SingleSelectOption
+                                        key={id}
+                                        value={id}
+                                        label={displayName}
+                                    />
+                                ))}
+                            </SingleSelectField>
+                        </div>
+                    )
+                })}
             </div>
 
             <Button

--- a/src/context-selection/attribute-option-combo-selector-bar-item/categories-menu.js
+++ b/src/context-selection/attribute-option-combo-selector-bar-item/categories-menu.js
@@ -16,7 +16,10 @@ export default function CategoriesMenu({
     selected,
     onChange,
 }) {
-    if (categories.length === 1) {
+    if (
+        categories.length === 1 &&
+        categories[0]?.categoryOptions?.length !== 0
+    ) {
         const category = categories[0]
         const values = category.categoryOptions.map(({ id, displayName }) => ({
             value: id,
@@ -50,7 +53,7 @@ export default function CategoriesMenu({
                             title={i18n.t('No available options')}
                         >
                             {i18n.t(
-                                `There are no options for {{categoryName}} for the selected period and organisation unit.`,
+                                `There are no options for {{categoryName}} for the selected period or organisation unit.`,
                                 { categoryName: displayName }
                             )}
                         </NoticeBox>

--- a/src/context-selection/attribute-option-combo-selector-bar-item/categories-menu.module.css
+++ b/src/context-selection/attribute-option-combo-selector-bar-item/categories-menu.module.css
@@ -14,3 +14,7 @@
 .input:last-child {
     margin-bottom: 0;
 }
+
+.noOptionsBox {
+    margin: var(--spacers-dp8)
+}

--- a/src/context-selection/attribute-option-combo-selector-bar-item/use-should-component-render-null.js
+++ b/src/context-selection/attribute-option-combo-selector-bar-item/use-should-component-render-null.js
@@ -10,7 +10,6 @@ export default function useShouldComponentRenderNull(categoryCombination) {
         !dataSetId ||
         !periodId ||
         !orgUnitId ||
-        // if it is the default combo, it'll already render null, see above
         !categoryCombination.categories.length
     )
 }

--- a/src/context-selection/attribute-option-combo-selector-bar-item/use-should-component-render-null.js
+++ b/src/context-selection/attribute-option-combo-selector-bar-item/use-should-component-render-null.js
@@ -1,9 +1,6 @@
 import { useDataSetId, useOrgUnitId, usePeriodId } from '../../shared/index.js'
 
-export default function useShouldComponentRenderNull(
-    categoryCombination,
-    categoryWithNoOptionsExists
-) {
+export default function useShouldComponentRenderNull(categoryCombination) {
     const [dataSetId] = useDataSetId()
     const [periodId] = usePeriodId()
     const [orgUnitId] = useOrgUnitId()
@@ -13,7 +10,6 @@ export default function useShouldComponentRenderNull(
         !dataSetId ||
         !periodId ||
         !orgUnitId ||
-        categoryWithNoOptionsExists ||
         // if it is the default combo, it'll already render null, see above
         !categoryCombination.categories.length
     )

--- a/src/data-workspace/data-workspace.js
+++ b/src/data-workspace/data-workspace.js
@@ -25,7 +25,7 @@ export const DataWorkspace = ({ selectionHasNoFormMessage }) => {
     if (selectionHasNoFormMessage) {
         const title = i18n.t('The current selection does not have a form')
         return (
-            <NoticeBox title={title} className={styles.formMessageBox}>
+            <NoticeBox title={title} className={styles.formMessageBox} error>
                 {selectionHasNoFormMessage}
             </NoticeBox>
         )

--- a/src/data-workspace/data-workspace.js
+++ b/src/data-workspace/data-workspace.js
@@ -24,7 +24,11 @@ export const DataWorkspace = ({ selectionHasNoFormMessage }) => {
 
     if (selectionHasNoFormMessage) {
         const title = i18n.t('The current selection does not have a form')
-        return <NoticeBox title={title}>{selectionHasNoFormMessage}</NoticeBox>
+        return (
+            <NoticeBox title={title} className={styles.formMessageBox}>
+                {selectionHasNoFormMessage}
+            </NoticeBox>
+        )
     }
 
     if (!isValidSelection) {

--- a/src/data-workspace/data-workspace.module.css
+++ b/src/data-workspace/data-workspace.module.css
@@ -34,3 +34,7 @@
   left: 0;
   transform: translateY(-100%);
 }
+
+.formMessageBox {
+    margin: var(--spacers-dp8) var(--spacers-dp12) var(--spacers-dp8) var(--spacers-dp12);
+}

--- a/src/shared/metadata/selectors.js
+++ b/src/shared/metadata/selectors.js
@@ -406,10 +406,11 @@ const isOptionWithinPeriod = ({
 }
 
 const isOptionAssignedToOrgUnit = ({ categoryOption, orgUnitId }) => {
-    if (!categoryOption?.organisationUnits) {
+    // by default,
+    if (!categoryOption?.organisationUnits?.length) {
         return true
     }
-    return categoryOption?.organistionUnits.includes(orgUnitId)
+    return categoryOption?.organisationUnits.includes(orgUnitId)
 }
 
 const resolveCategoryOptionIds = (categories, categoryOptions) => {
@@ -422,7 +423,7 @@ const resolveCategoryOptionIds = (categories, categoryOptions) => {
 }
 
 /* eslint-disable max-params */
-export const getCategoriesWithOptionsWithinPeriodForOrgUnit =
+export const getCategoriesWithOptionsWithinPeriodWithOrgUnit =
     createCachedSelector(
         (metadata) => metadata,
         getDataSetById,

--- a/src/shared/metadata/selectors.js
+++ b/src/shared/metadata/selectors.js
@@ -405,6 +405,13 @@ const isOptionWithinPeriod = ({
     return true
 }
 
+const isOptionAssignedToOrgUnit = ({ categoryOption, orgUnitId }) => {
+    if (!categoryOption?.organisationUnits) {
+        return true
+    }
+    return categoryOption?.organistionUnits.includes(orgUnitId)
+}
+
 const resolveCategoryOptionIds = (categories, categoryOptions) => {
     return categories.map((category) => ({
         ...category,
@@ -414,58 +421,71 @@ const resolveCategoryOptionIds = (categories, categoryOptions) => {
     }))
 }
 
-export const getCategoriesWithOptionsWithinPeriod = createCachedSelector(
-    (metadata) => metadata,
-    getDataSetById,
-    (_, __, periodId) => periodId,
-    (metadata, dataSet, periodId) => {
-        if (!dataSet?.id || !periodId) {
-            return []
-        }
+/* eslint-disable max-params */
+export const getCategoriesWithOptionsWithinPeriodForOrgUnit =
+    createCachedSelector(
+        (metadata) => metadata,
+        getDataSetById,
+        (_, __, periodId) => periodId,
+        (_, __, ___, orgUnitId) => orgUnitId,
+        (metadata, dataSet, periodId, orgUnitId) => {
+            if (!dataSet?.id || !periodId) {
+                return []
+            }
 
-        const relevantCategories = getCategoriesByDataSetId(
-            metadata,
-            dataSet?.id
-        )
+            const relevantCategories = getCategoriesByDataSetId(
+                metadata,
+                dataSet?.id
+            )
 
-        const categoryOptions = getCategoryOptions(metadata)
-        const relevantCategoriesWithOptions = resolveCategoryOptionIds(
-            relevantCategories,
-            categoryOptions
-        )
-        const period = parsePeriodId(periodId)
-        const periodStartDate = new Date(period.startDate)
+            const categoryOptions = getCategoryOptions(metadata)
 
-        // periodEndDate is up to following start date
-        let periodEndDate = addFullPeriodTimeToDate(
-            periodStartDate,
-            period?.periodType?.type
-        )
+            const relevantCategoriesWithOptions = resolveCategoryOptionIds(
+                relevantCategories,
+                categoryOptions
+            )
+            const period = parsePeriodId(periodId)
+            const periodStartDate = new Date(period.startDate)
 
-        // reduce perfiodEndDate by openPeriodsAfterCoEndDate
-        const openPeriodsAfterCoEndDate = Math.max(
-            dataSet?.openPeriodsAfterCoEndDate || 0,
-            0
-        )
-        for (let i = 0; i < openPeriodsAfterCoEndDate; i++) {
-            periodEndDate = removeFullPeriodTimeToDate(
-                periodEndDate,
+            // periodEndDate is up to following start date
+            let periodEndDate = addFullPeriodTimeToDate(
+                periodStartDate,
                 period?.periodType?.type
             )
-        }
 
-        // remove 1 day because endDate is 1 less than subsequent startDate
-        periodEndDate.setDate(periodEndDate.getDate() - 1)
-
-        return relevantCategoriesWithOptions.map((category) => ({
-            ...category,
-            categoryOptions: category.categoryOptions.filter((categoryOption) =>
-                isOptionWithinPeriod({
-                    periodStartDate,
+            // reduce perfiodEndDate by openPeriodsAfterCoEndDate
+            const openPeriodsAfterCoEndDate = Math.max(
+                dataSet?.openPeriodsAfterCoEndDate || 0,
+                0
+            )
+            for (let i = 0; i < openPeriodsAfterCoEndDate; i++) {
+                periodEndDate = removeFullPeriodTimeToDate(
                     periodEndDate,
-                    categoryOption,
-                })
-            ),
-        }))
-    }
-)((_, dataSetId, periodId) => `${dataSetId}:${periodId}`)
+                    period?.periodType?.type
+                )
+            }
+
+            // remove 1 day because endDate is 1 less than subsequent startDate
+            periodEndDate.setDate(periodEndDate.getDate() - 1)
+
+            return relevantCategoriesWithOptions.map((category) => ({
+                ...category,
+                categoryOptions: category.categoryOptions.filter(
+                    (categoryOption) =>
+                        isOptionWithinPeriod({
+                            periodStartDate,
+                            periodEndDate,
+                            categoryOption,
+                        }) &&
+                        isOptionAssignedToOrgUnit({
+                            categoryOption,
+                            orgUnitId,
+                        })
+                ),
+            }))
+        }
+    )(
+        (_, dataSetId, periodId, orgUnitId) =>
+            `${dataSetId}:${periodId}:${orgUnitId}`
+    )
+/* eslint-enable max-params */

--- a/src/shared/metadata/selectors.test.js
+++ b/src/shared/metadata/selectors.test.js
@@ -955,5 +955,149 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
 
             expect(actual).toEqual(expected)
         })
+
+        it('should return all category options if none have assigned orgunits', () => {
+            const datasetid = 'dataset-id-1a'
+            const periodid = '202201'
+            const orgunitid = 'orgunit-id-z'
+
+            const catcomboid = 'categorycombo-id-1'
+
+            const metadata = {
+                dataSets: {
+                    [datasetid]: {
+                        categoryCombo: { id: catcomboid },
+                        periodType: 'Monthly',
+                        id: datasetid,
+                    },
+                },
+                categoryCombos: {
+                    [catcomboid]: {
+                        id: catcomboid,
+                        categories: ['co-id-letter', 'co-id-number'],
+                    },
+                },
+                categories: {
+                    'co-id-letter': {
+                        id: 'co-id-letter',
+                        categoryOptions: ['cat-id-a', 'cat-id-b', 'cat-id-c'],
+                    },
+                    'co-id-number': {
+                        id: 'co-id-number',
+                        categoryOptions: ['cat-id-1', 'cat-id-2'],
+                    },
+                },
+                categoryOptions: {
+                    'cat-id-a': { id: 'cat-id-a', organisationUnits: [] },
+                    'cat-id-b': { id: 'cat-id-b', organisationUnits: [] },
+                    'cat-id-c': { id: 'cat-id-c', organisationUnits: [] },
+                    'cat-id-1': { id: 'cat-id-1', organisationUnits: [] },
+                    'cat-id-2': { id: 'cat-id-2' },
+                },
+            }
+
+            const expected = [
+                {
+                    categoryOptions: [
+                        { id: 'cat-id-a', organisationUnits: [] },
+                        { id: 'cat-id-b', organisationUnits: [] },
+                        { id: 'cat-id-c', organisationUnits: [] },
+                    ],
+                    id: 'co-id-letter',
+                },
+                {
+                    categoryOptions: [
+                        { id: 'cat-id-1', organisationUnits: [] },
+                        { id: 'cat-id-2' },
+                    ],
+                    id: 'co-id-number',
+                },
+            ]
+
+            const actual = getCategoriesWithOptionsWithinPeriodWithOrgUnit(
+                metadata,
+                datasetid,
+                periodid,
+                orgunitid
+            )
+
+            expect(actual).toEqual(expected)
+        })
+
+        it('should return relevant category options if some have restricted org units', () => {
+            const datasetid = 'dataset-id-1a'
+            const periodid = '202201'
+            const orgunitid = 'orgunit-id-z'
+
+            const catcomboid = 'categorycombo-id-1'
+
+            const metadata = {
+                dataSets: {
+                    [datasetid]: {
+                        categoryCombo: { id: catcomboid },
+                        periodType: 'Monthly',
+                        id: datasetid,
+                    },
+                },
+                categoryCombos: {
+                    [catcomboid]: {
+                        id: catcomboid,
+                        categories: ['co-id-letter', 'co-id-number'],
+                    },
+                },
+                categories: {
+                    'co-id-letter': {
+                        id: 'co-id-letter',
+                        categoryOptions: ['cat-id-a', 'cat-id-b', 'cat-id-c'],
+                    },
+                    'co-id-number': {
+                        id: 'co-id-number',
+                        categoryOptions: ['cat-id-1', 'cat-id-2'],
+                    },
+                },
+                categoryOptions: {
+                    'cat-id-a': {
+                        id: 'cat-id-a',
+                        organisationUnits: ['fake-orgunit1'],
+                    },
+                    'cat-id-b': {
+                        id: 'cat-id-b',
+                        organisationUnits: ['fake-orgunit1'],
+                    },
+                    'cat-id-c': {
+                        id: 'cat-id-c',
+                        organisationUnits: ['fake-orgunit2'],
+                    },
+                    'cat-id-1': {
+                        id: 'cat-id-1',
+                        organisationUnits: ['orgunit-id-z'],
+                    },
+                    'cat-id-2': { id: 'cat-id-2', organisationUnits: [] },
+                },
+            }
+
+            const expected = [
+                {
+                    categoryOptions: [],
+                    id: 'co-id-letter',
+                },
+                {
+                    categoryOptions: [
+                        { id: 'cat-id-1', organisationUnits: ['orgunit-id-z'] },
+                        { id: 'cat-id-2', organisationUnits: [] },
+                    ],
+                    id: 'co-id-number',
+                },
+            ]
+
+            const actual = getCategoriesWithOptionsWithinPeriodWithOrgUnit(
+                metadata,
+                datasetid,
+                periodid,
+                orgunitid
+            )
+
+            expect(actual).toEqual(expected)
+        })
     })
 })

--- a/src/shared/metadata/selectors.test.js
+++ b/src/shared/metadata/selectors.test.js
@@ -10,7 +10,7 @@ import {
     getCategoryOptions,
     getCategoryOptionsByCategoryId,
     getCategoryOptionsByCategoryOptionComboId,
-    getCategoriesWithOptionsWithinPeriod,
+    getCategoriesWithOptionsWithinPeriodForOrgUnit,
     getCoCByCategoryOptions,
     getDataElements,
     getDataElementsByDataSetId,
@@ -761,10 +761,11 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
         expect(actual).toEqual(expected)
     })
 
-    describe('getCategoriesWithOptionsWithinPeriod', () => {
+    describe('getCategoriesWithOptionsWithinPeriodForOrgUnit', () => {
         it('should return all category options if none have end dates', () => {
             const datasetid = 'dataset-id-1a'
             const periodid = '202201'
+            const orgunitid = 'orgunit-id-z'
 
             const catcomboid = 'categorycombo-id-1'
 
@@ -816,10 +817,11 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
                 },
             ]
 
-            const actual = getCategoriesWithOptionsWithinPeriod(
+            const actual = getCategoriesWithOptionsWithinPeriodForOrgUnit(
                 metadata,
                 datasetid,
-                periodid
+                periodid,
+                orgunitid
             )
 
             expect(actual).toEqual(expected)
@@ -828,6 +830,7 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
         it('should return category options without endDate or with endDate after period end ', () => {
             const datasetid = 'dataset-id-1a'
             const periodid = '202201'
+            const orgunitid = 'orgunit-id-z'
 
             const catcomboid = 'categorycombo-id-1'
 
@@ -875,10 +878,11 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
                 },
             ]
 
-            const actual = getCategoriesWithOptionsWithinPeriod(
+            const actual = getCategoriesWithOptionsWithinPeriodForOrgUnit(
                 metadata,
                 datasetid,
-                periodid
+                periodid,
+                orgunitid
             )
 
             expect(actual).toEqual(expected)
@@ -887,6 +891,7 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
         it('should return category options without endDate or with endDate after period end, adjusting for openPeriodsAfterCoEndDate', () => {
             const datasetid = 'dataset-id-1a'
             const periodid = '202201'
+            const orgunitid = 'orgunit-id-z'
 
             const catcomboid = 'categorycombo-id-1'
 
@@ -941,10 +946,11 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
                 },
             ]
 
-            const actual = getCategoriesWithOptionsWithinPeriod(
+            const actual = getCategoriesWithOptionsWithinPeriodForOrgUnit(
                 metadata,
                 datasetid,
-                periodid
+                periodid,
+                orgunitid
             )
 
             expect(actual).toEqual(expected)

--- a/src/shared/metadata/selectors.test.js
+++ b/src/shared/metadata/selectors.test.js
@@ -10,7 +10,7 @@ import {
     getCategoryOptions,
     getCategoryOptionsByCategoryId,
     getCategoryOptionsByCategoryOptionComboId,
-    getCategoriesWithOptionsWithinPeriodForOrgUnit,
+    getCategoriesWithOptionsWithinPeriodWithOrgUnit,
     getCoCByCategoryOptions,
     getDataElements,
     getDataElementsByDataSetId,
@@ -761,7 +761,7 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
         expect(actual).toEqual(expected)
     })
 
-    describe('getCategoriesWithOptionsWithinPeriodForOrgUnit', () => {
+    describe('getCategoriesWithOptionsWithinPeriodWithOrgUnit', () => {
         it('should return all category options if none have end dates', () => {
             const datasetid = 'dataset-id-1a'
             const periodid = '202201'
@@ -817,7 +817,7 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
                 },
             ]
 
-            const actual = getCategoriesWithOptionsWithinPeriodForOrgUnit(
+            const actual = getCategoriesWithOptionsWithinPeriodWithOrgUnit(
                 metadata,
                 datasetid,
                 periodid,
@@ -878,7 +878,7 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
                 },
             ]
 
-            const actual = getCategoriesWithOptionsWithinPeriodForOrgUnit(
+            const actual = getCategoriesWithOptionsWithinPeriodWithOrgUnit(
                 metadata,
                 datasetid,
                 periodid,
@@ -946,7 +946,7 @@ describe('getCategoryOptionsByCategoryOptionComboId', () => {
                 },
             ]
 
-            const actual = getCategoriesWithOptionsWithinPeriodForOrgUnit(
+            const actual = getCategoriesWithOptionsWithinPeriodWithOrgUnit(
                 metadata,
                 datasetid,
                 periodid,

--- a/src/shared/use-context-selection/use-manage-inter-param-dependencies.js
+++ b/src/shared/use-context-selection/use-manage-inter-param-dependencies.js
@@ -75,11 +75,12 @@ function useHandleOrgUnitIdChange() {
         useAttributeOptionComboSelection()
 
     const relevantCategoriesWithOptions =
-        selectors.getCategoriesWithOptionsWithinPeriod(
+        selectors.getCategoriesWithOptionsWithinPeriodForOrgUnit({
             metadata,
             dataSetId,
-            periodId
-        )
+            periodId,
+            orgUnitId,
+        })
 
     useEffect(() => {
         if (orgUnitId !== prevOrgUnitId) {
@@ -149,14 +150,16 @@ function useHandlePeriodIdChange() {
     const [attributeOptionComboSelection, setAttributeOptionComboSelection] =
         useAttributeOptionComboSelection()
     const [dataSetId] = useDataSetId()
+    const [orgUnitId] = useOrgUnitId()
     const [periodId] = usePeriodId()
     const [prevPeriodId, setPrevPeriodId] = useState(periodId)
     const relevantCategoriesWithOptions =
-        selectors.getCategoriesWithOptionsWithinPeriod(
+        selectors.getCategoriesWithOptionsWithinPeriodForOrgUnit({
             metadata,
             dataSetId,
-            periodId
-        )
+            periodId,
+            orgUnitId,
+        })
 
     useEffect(() => {
         if (periodId !== prevPeriodId) {

--- a/src/shared/use-context-selection/use-manage-inter-param-dependencies.js
+++ b/src/shared/use-context-selection/use-manage-inter-param-dependencies.js
@@ -75,7 +75,7 @@ function useHandleOrgUnitIdChange() {
         useAttributeOptionComboSelection()
 
     const relevantCategoriesWithOptions =
-        selectors.getCategoriesWithOptionsWithinPeriodForOrgUnit({
+        selectors.getCategoriesWithOptionsWithinPeriodWithOrgUnit({
             metadata,
             dataSetId,
             periodId,
@@ -154,7 +154,7 @@ function useHandlePeriodIdChange() {
     const [periodId] = usePeriodId()
     const [prevPeriodId, setPrevPeriodId] = useState(periodId)
     const relevantCategoriesWithOptions =
-        selectors.getCategoriesWithOptionsWithinPeriodForOrgUnit({
+        selectors.getCategoriesWithOptionsWithinPeriodWithOrgUnit({
             metadata,
             dataSetId,
             periodId,


### PR DESCRIPTION
This PR restricts the selectable attribute options based on the organisation units assigned to the underlying category option.

Additionally, it updates the UI (as discussed on the ticket https://dhis2.atlassian.net/browse/TECH-1326), to communicate when form cannot be selected because no valid attribute options exist for the select organisation unit/period. 