### PR TITLE
fix(history): add comment for no history ui

### DIFF
--- a/src/data-workspace/data-details-sidebar/history.js
+++ b/src/data-workspace/data-details-sidebar/history.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { ExpandableUnit, useConnectionStatus } from '../../shared/index.js'
 import HistoryLineChart from './history-line-chart.js'
+import styles from './history.module.css'
 import useDataValueContext from './use-data-value-context.js'
 import useOpenState from './use-open-state.js'
 
@@ -52,7 +53,9 @@ export default function History({ item }) {
     if (!history.length) {
         return (
             <ExpandableUnit title={title} open={open} onToggle={setOpen}>
-                <p>{'@TODO: ' + i18n.t('Show ui for no history')}</p>
+                <p className={styles.placeholder}>
+                    {i18n.t('No history for this data item.')}
+                </p>
             </ExpandableUnit>
         )
     }

--- a/src/data-workspace/data-details-sidebar/history.module.css
+++ b/src/data-workspace/data-details-sidebar/history.module.css
@@ -1,0 +1,6 @@
+.placeholder {
+    margin: 0;
+    font-size: 14px;
+    line-height: 19px;
+    color: var(--colors-grey600);
+}


### PR DESCRIPTION
Adds a 'No history' message in the same style as the other details sidebar item with no values.

I think it's a bit silly to add a style sheet for this one class, but I thought this was most in line with what we're doing in this section of the code. 