### PR TITLE
feat(comment): add comment option sets where applicable [TECH-1350]

### DIFF
--- a/src/data-workspace/data-details-sidebar/comment.js
+++ b/src/data-workspace/data-details-sidebar/comment.js
@@ -19,20 +19,12 @@ const errorMessage = i18n.t(
     'There was a problem loading the comment for this data item'
 )
 
-const CommentOptionSelector = ({
-    commentOptionSetId,
-    inputOnChange,
-    comment,
-}) => {
+const CommentOptionSelector = ({ commentOptionSetId, inputOnChange }) => {
     const { data: metadata } = useMetadata()
 
     const optionSet = selectors.getOptionSetById(metadata, commentOptionSetId)
     // filter out 'null' options
     const options = optionSet?.options?.filter((opt) => !!opt)
-
-    const [selectedCommentOption, setSelectedCommentOption] = useState(
-        options?.find((o) => o.displayName === comment)?.code
-    )
 
     if (!(options?.length > 0)) {
         return null
@@ -40,10 +32,8 @@ const CommentOptionSelector = ({
 
     return (
         <SingleSelect
-            selected={selectedCommentOption}
             placeholder={i18n.t('Choose an option')}
             onChange={({ selected }) => {
-                setSelectedCommentOption(selected)
                 inputOnChange(
                     options.find((o) => o.code === selected)?.displayName
                 )
@@ -58,7 +48,6 @@ const CommentOptionSelector = ({
 }
 
 CommentOptionSelector.propTypes = {
-    comment: PropTypes.string,
     commentOptionSetId: PropTypes.string,
     inputOnChange: PropTypes.func,
 }
@@ -75,7 +64,6 @@ const CommentEditField = ({ comment, commentOptionSetId }) => {
                 <CommentOptionSelector
                     commentOptionSetId={commentOptionSetId}
                     inputOnChange={input.onChange}
-                    comment={comment}
                 />
             )}
             <textarea

--- a/src/data-workspace/data-details-sidebar/comment.module.css
+++ b/src/data-workspace/data-details-sidebar/comment.module.css
@@ -18,5 +18,31 @@
 }
 
 .textArea {
+    box-sizing: border-box;
+    color: var(--colors-grey900);
+    background-color: transparent;
+    border: 1px solid var(--colors-grey500);
+    border-radius: 3px;
+    box-shadow: inset 0 0 0 1px rgba(102, 113, 123, 0.15),
+        inset 0 1px 2px 0 rgba(102, 113, 123, 0.1);
+    outline: 0;
+    font-size: 14px;
+    line-height: 16px;
+    user-select: text;
+}
+
+.textAreaDense {
+    composes: textArea;
+    padding: 4px 12px;
+}
+
+.commentInput {
+    composes: textAreaDense;
+    width: 100%;
+    resize: vertical;
     margin-bottom: var(--spacers-dp12);
+}
+
+.commentOptionSelect {
+    margin-bottom: var(--spacers-dp8);
 }

--- a/src/data-workspace/data-details-sidebar/comment.test.js
+++ b/src/data-workspace/data-details-sidebar/comment.test.js
@@ -1,6 +1,7 @@
 import { fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React, { useState } from 'react'
+import { useMetadata } from '../../shared/metadata/use-metadata.js'
 import { render } from '../../test-utils/index.js'
 import { useSetDataValueMutation } from '../data-value-mutations/index.js'
 import Comment from './comment.js'
@@ -9,6 +10,10 @@ import Comment from './comment.js'
 
 jest.mock('../data-value-mutations/index.js', () => ({
     useSetDataValueMutation: jest.fn(() => ({})),
+}))
+
+jest.mock('../../shared/metadata/use-metadata.js', () => ({
+    useMetadata: jest.fn(() => ({})),
 }))
 
 describe('<Comment />', () => {
@@ -97,6 +102,82 @@ describe('<Comment />', () => {
         expect(queryByRole('progressbar')).not.toBeInTheDocument()
         userEvent.click(getByRole('button', { name: 'Save comment' }))
         expect(getByRole('progressbar')).toBeInTheDocument()
+    })
+
+    it('shows a drop down with relevant options when data element has a commentOptionSet', async () => {
+        useMetadata.mockImplementation(() => ({
+            data: {
+                optionSets: {
+                    optSet1: {
+                        options: [
+                            { id: 'opt1', code: 'OPT1', displayName: 'Ole' },
+                            { id: 'opt2', code: 'OPT2', displayName: 'Dole' },
+                            { id: 'opt3', code: 'OPT3', displayName: 'Doffen' },
+                        ],
+                    },
+                },
+            },
+        }))
+
+        const item = {
+            categoryOptionCombo: 'coc-id',
+            dataElement: 'de-id',
+            commentOptionSetId: 'optSet1',
+        }
+
+        const { getByRole, getByText, queryByRole } = render(
+            <Comment item={item} />
+        )
+
+        userEvent.click(getByRole('button', { name: 'Add comment' }))
+
+        await waitFor(() => {
+            expect(queryByRole('textbox')).toBeInTheDocument()
+        })
+
+        userEvent.click(getByText('Choose an option'))
+
+        await waitFor(() => {
+            expect(getByText('Doffen')).toBeInTheDocument()
+        })
+    })
+
+    it('sets the comment text to selected option if there is an option set and user selects an option ', async () => {
+        useMetadata.mockImplementation(() => ({
+            data: {
+                optionSets: {
+                    optSet1: {
+                        options: [
+                            { id: 'opt1', code: 'OPT1', displayName: 'Ole' },
+                            { id: 'opt2', code: 'OPT2', displayName: 'Dole' },
+                            { id: 'opt3', code: 'OPT3', displayName: 'Doffen' },
+                        ],
+                    },
+                },
+            },
+        }))
+
+        const item = {
+            categoryOptionCombo: 'coc-id',
+            dataElement: 'de-id',
+            commentOptionSetId: 'optSet1',
+            comment: 'an existing comment not about donald duck',
+        }
+
+        const { getByRole, getByText, queryByRole } = render(
+            <Comment item={item} />
+        )
+
+        userEvent.click(getByRole('button', { name: 'Edit comment' }))
+
+        await waitFor(() => {
+            expect(queryByRole('textbox')).toBeInTheDocument()
+        })
+
+        userEvent.click(getByText('Choose an option'))
+        userEvent.click(getByText('Doffen'))
+
+        expect(getByRole('textbox').value).toBe('Doffen')
     })
 
     it('shows a the error message when submitting a comment fails', async () => {

--- a/src/shared/highlighted-field/use-highlighted-field.js
+++ b/src/shared/highlighted-field/use-highlighted-field.js
@@ -5,7 +5,7 @@ import { useHighlightedFieldIdContext } from './use-highlighted-field-context.js
 
 function gatherHighlightedFieldData({ de, coc, dataValueSet }) {
     const dataValue = dataValueSet?.dataValues[de.id]?.[coc.id]
-    const { optionSet, valueType } = de
+    const { optionSet, valueType, commentOptionSet } = de
     const canHaveLimits = optionSet
         ? false
         : CAN_HAVE_LIMITS_TYPES.includes(valueType)
@@ -18,6 +18,7 @@ function gatherHighlightedFieldData({ de, coc, dataValueSet }) {
             categoryOptionCombo: coc.id,
             name: de.displayName,
             code: de.code,
+            commentOptionSetId: commentOptionSet?.id,
         }
     }
 
@@ -32,6 +33,7 @@ function gatherHighlightedFieldData({ de, coc, dataValueSet }) {
         comment: null,
         storedBy: null,
         code: null,
+        commentOptionSetId: commentOptionSet?.id,
     }
 }
 


### PR DESCRIPTION
**_In draft mode until dev branches are on core build with commentOptionSets included in api/dataEntry/metadata._**

**Notes**

- I essentially replicated the UI in the existing app. User selects a comment from drop down, which populates in textarea, which can then be edited before being saved. Selected option is not persisted in drop down:

![comment_option](https://user-images.githubusercontent.com/18490902/188153525-bc54a4f1-f08c-4edc-8a34-b819b9088c1a.gif)

I looked at persisting that selection in the drop down, but thought maybe it looked weirder:
<img width="317" alt="image" src="https://user-images.githubusercontent.com/18490902/188153678-ddd3fdb1-22a3-4d8b-9a45-05a8a4125123.png">

- The comment textarea was previously using the TextAreaFieldFF component. Rather than hacking this to use as a non-standalone FinalForm component, I've imported the underlying styling for this component and just applied that on a <textarea> element.


