### PR TITLE
fix(validation sidebar): clean up validation sidebar

### DIFF
--- a/src/data-workspace/validation/validation-comments-violations.js
+++ b/src/data-workspace/validation/validation-comments-violations.js
@@ -34,7 +34,10 @@ const ValidationCommentsViolations = ({ commentRequiredViolations }) => {
                             >
                                 {i18n.t(
                                     "{{displayShortName}} must have a comment when it doesn't have a value.",
-                                    { displayShortName }
+                                    {
+                                        displayShortName,
+                                        interpolation: { escapeValue: false },
+                                    }
                                 )}
                             </div>
                         )

--- a/src/data-workspace/validation/validation-results-sidebar.js
+++ b/src/data-workspace/validation/validation-results-sidebar.js
@@ -102,7 +102,7 @@ export default function ValidationResultsSidebar({ hide }) {
                             />
                         )
                     })}
-                {!showLoader && isEmpty && (
+                {!showLoader && isEmpty && !hasCommentsViolations && (
                     <div className={styles.noAlerts}>
                         {i18n.t('No validation alerts for this data.')}
                     </div>

--- a/src/data-workspace/validation/validation-results-sidebar.js
+++ b/src/data-workspace/validation/validation-results-sidebar.js
@@ -35,13 +35,14 @@ export default function ValidationResultsSidebar({ hide }) {
 
     const hasRunningMutations = activeMutations > 0
 
+    const hasCommentsViolations = Boolean(commentRequiredViolations?.length)
+
     const isEmpty =
         validationRuleViolations &&
         Object.values(validationRuleViolations).every(
             (ruleViolations) => ruleViolations.length === 0
-        )
-
-    const hasCommentsViolations = Boolean(commentRequiredViolations?.length)
+        ) &&
+        !hasCommentsViolations
 
     const rerunValidation = () => {
         setFormChangedSincePanelOpened(false)
@@ -102,7 +103,7 @@ export default function ValidationResultsSidebar({ hide }) {
                             />
                         )
                     })}
-                {!showLoader && isEmpty && !hasCommentsViolations && (
+                {!showLoader && isEmpty && (
                     <div className={styles.noAlerts}>
                         {i18n.t('No validation alerts for this data.')}
                     </div>


### PR DESCRIPTION
- turns off escaping of data element short names in comment violation errors ([TECH-1331](https://dhis2.atlassian.net/browse/TECH-1331))
- hides `No validation alerts for this data` text if there are comment violations ([TECH-1330](https://dhis2.atlassian.net/browse/TECH-1330))