### PR TITLE
fix(help sidebar): remove double click text [TECH-1291]

### DIFF
--- a/src/context-selection/contextual-help-sidebar/shortcuts.js
+++ b/src/context-selection/contextual-help-sidebar/shortcuts.js
@@ -34,11 +34,7 @@ export default function Shortcuts() {
         >
             <Action
                 label={i18n.t('Show details')}
-                shortcuts={[
-                    i18n.t('Ctrl + Enter'),
-                    i18n.t('Cmd + Enter'),
-                    i18n.t('Double click'),
-                ]}
+                shortcuts={[i18n.t('Ctrl + Enter'), i18n.t('Cmd + Enter')]}
             />
 
             <Divider />


### PR DESCRIPTION
This removes reference to double clicking to open data details. See decisions on ticket: https://dhis2.atlassian.net/browse/TECH-1291