### PR TITLE
fix: resume queries when reloading app

### DIFF
--- a/src/app/query-client/configured-query-client-provider.js
+++ b/src/app/query-client/configured-query-client-provider.js
@@ -39,13 +39,7 @@ export const ConfiguredQueryClientProvider = ({ queryClient, children }) => {
             client={queryClient}
             persistOptions={persistOptions}
             onSuccess={() => {
-                console.log('resuming mutations')
-                queryClient
-                    .resumePausedMutations()
-                    .then(() => {
-                        console.log('resumed')
-                    })
-                    .catch(() => console.log('failed to resume'))
+                queryClient.resumePausedMutations()
             }}
         >
             {children}

--- a/src/app/query-client/configured-query-client-provider.js
+++ b/src/app/query-client/configured-query-client-provider.js
@@ -33,7 +33,6 @@ const persistOptions = {
     },
 }
 export const ConfiguredQueryClientProvider = ({ queryClient, children }) => {
-    console.log('provider')
     return (
         <PersistQueryClientProvider
             client={queryClient}

--- a/src/app/query-client/configured-query-client-provider.js
+++ b/src/app/query-client/configured-query-client-provider.js
@@ -33,10 +33,20 @@ const persistOptions = {
     },
 }
 export const ConfiguredQueryClientProvider = ({ queryClient, children }) => {
+    console.log('provider')
     return (
         <PersistQueryClientProvider
             client={queryClient}
             persistOptions={persistOptions}
+            onSuccess={() => {
+                console.log('resuming mutations')
+                queryClient
+                    .resumePausedMutations()
+                    .then(() => {
+                        console.log('resumed')
+                    })
+                    .catch(() => console.log('failed to resume'))
+            }}
         >
             {children}
         </PersistQueryClientProvider>

--- a/src/app/query-client/use-query-client.js
+++ b/src/app/query-client/use-query-client.js
@@ -1,6 +1,6 @@
 import { useDataEngine } from '@dhis2/app-runtime'
 import { QueryClient } from '@tanstack/react-query'
-import { useSetDataValueMutationDefaults } from '../../data-workspace/data-value-mutations/index.js'
+import { setDataValueMutationDefaults } from '../../data-workspace/data-value-mutations/index.js'
 import createQueryFn from './create-query-fn.js'
 
 const logger = {
@@ -29,7 +29,7 @@ const useQueryClient = () => {
     // set mutation defaults
     // we need default mutation functions for each query-key
     // so that paused mutations can resume after a page reload
-    useSetDataValueMutationDefaults(queryClient)
+    setDataValueMutationDefaults(queryClient, engine)
 
     return queryClient
 }

--- a/src/app/query-client/use-query-client.js
+++ b/src/app/query-client/use-query-client.js
@@ -27,7 +27,7 @@ const useQueryClient = () => {
     })
 
     // set mutation defaults
-    // we need mutation functions for each query-key
+    // we need default mutation functions for each query-key
     // so that paused mutations can resume after a page reload
     useSetDataValueMutationDefaults(queryClient)
 

--- a/src/app/query-client/use-query-client.js
+++ b/src/app/query-client/use-query-client.js
@@ -1,5 +1,6 @@
 import { useDataEngine } from '@dhis2/app-runtime'
 import { QueryClient } from '@tanstack/react-query'
+import { useSetDataValueMutationDefaults } from '../../data-workspace/data-value-mutations/index.js'
 import createQueryFn from './create-query-fn.js'
 
 const logger = {
@@ -25,22 +26,10 @@ const useQueryClient = () => {
         },
     })
 
-    queryClient.setMutationDefaults(['dataValues'], {
-        mutationFn: async function (variables) {
-            const { mutationKey } = this
-            const { params } = mutationKey[1]
-
-            await queryClient.cancelQueries(mutationKey)
-            const mutationObj = {
-                resource: 'dataValues',
-                type: 'create',
-                data: (data) => data,
-            }
-            return engine.mutate(mutationObj, {
-                variables: { ...params, ...variables },
-            })
-        },
-    })
+    // set mutation defaults
+    // we need mutation functions for each query-key
+    // so that paused mutations can resume after a page reload
+    useSetDataValueMutationDefaults(queryClient)
 
     return queryClient
 }

--- a/src/app/query-client/use-query-client.js
+++ b/src/app/query-client/use-query-client.js
@@ -25,6 +25,23 @@ const useQueryClient = () => {
         },
     })
 
+    queryClient.setMutationDefaults(['dataValues'], {
+        mutationFn: async function (variables) {
+            const { mutationKey } = this
+            const { params } = mutationKey[1]
+
+            await queryClient.cancelQueries(mutationKey)
+            const mutationObj = {
+                resource: 'dataValues',
+                type: 'create',
+                data: (data) => data,
+            }
+            return engine.mutate(mutationObj, {
+                variables: { ...params, ...variables },
+            })
+        },
+    })
+
     return queryClient
 }
 

--- a/src/data-workspace/data-entry-cell/inner-wrapper.js
+++ b/src/data-workspace/data-entry-cell/inner-wrapper.js
@@ -7,7 +7,7 @@ import { useField } from 'react-final-form'
 import { useHighlightedFieldIdContext } from '../../shared/index.js'
 import {
     useDataValueParams,
-    getDataValueMutationKey,
+    mutationKeys as dataValueMutationKeys,
 } from '../data-value-mutations/index.js'
 import { useHasComment } from '../has-comment/has-comment-context.js'
 import styles from './data-entry-cell.module.css'
@@ -61,7 +61,7 @@ export function InnerWrapper({
     // Detect if this field is sending data
     const dataValueParams = useDataValueParams({ deId, cocId })
     const activeMutations = useIsMutating({
-        mutationKey: getDataValueMutationKey(dataValueParams),
+        mutationKey: dataValueMutationKeys.all(dataValueParams),
     })
 
     // todo: maybe use mutation state to improve this style handling

--- a/src/data-workspace/data-value-mutations/data-value-mutations.js
+++ b/src/data-workspace/data-value-mutations/data-value-mutations.js
@@ -107,15 +107,3 @@ export function useDeleteDataValueMutation({ deId, cocId }) {
         optimisticUpdateFn: optimisticallyDeleteDataValue,
     })
 }
-
-export function useSetDataValueMutationDefaults(queryClient) {
-    queryClient.setMutationDefaults(mutationKeys.file(), {
-        mutationFn: useUploadFileDataValueMutationFunction(),
-    })
-    queryClient.setMutationDefaults(mutationKeys.update(), {
-        mutationFn: useSetDataValueMutationFunction(),
-    })
-    queryClient.setMutationDefaults(mutationKeys.delete(), {
-        mutationFn: useDeleteDataValueMutationFunction(),
-    })
-}

--- a/src/data-workspace/data-value-mutations/data-value-mutations.js
+++ b/src/data-workspace/data-value-mutations/data-value-mutations.js
@@ -10,14 +10,12 @@ import {
     useSetDataValueMutationFunction,
     useUploadFileDataValueMutationFunction,
 } from './mutation-functions.js'
+import { mutationKeys } from './mutation-key-factory.js'
 import useApiError from './use-api-error.js'
 import { useDataValueParams } from './use-data-value-params.js'
 
-export function getDataValueMutationKey(dataValueParams) {
-    return ['dataValues', { params: dataValueParams }]
-}
-
 function useSharedDataValueMutation({
+    mutationKey,
     dataValueParams,
     mutationFn,
     optimisticUpdateFn,
@@ -28,7 +26,7 @@ function useSharedDataValueMutation({
 
     return useMutation(mutationFn, {
         retry: 1,
-        mutationKey: getDataValueMutationKey(dataValueParams),
+        mutationKey: mutationKey,
 
         onMutate: async (variables) => {
             // Cancel any outgoing refetches (so they don't overwrite our optimistic update)
@@ -73,10 +71,11 @@ function useSharedDataValueMutation({
  */
 export function useSetDataValueMutation({ deId, cocId }) {
     const dataValueParams = useDataValueParams({ deId, cocId })
-    const mutationFn = useSetDataValueMutationFunction(dataValueParams)
+    const mutationFn = useSetDataValueMutationFunction()
 
     return useSharedDataValueMutation({
         dataValueParams,
+        mutationKey: mutationKeys.update(dataValueParams),
         mutationFn,
         optimisticUpdateFn: optimisticallySetDataValue,
     })
@@ -87,9 +86,10 @@ export function useSetDataValueMutation({ deId, cocId }) {
  */
 export function useUploadFileDataValueMutation({ deId, cocId }) {
     const dataValueParams = useDataValueParams({ deId, cocId })
-    const mutationFn = useUploadFileDataValueMutationFunction(dataValueParams)
+    const mutationFn = useUploadFileDataValueMutationFunction()
 
     return useSharedDataValueMutation({
+        mutationKey: mutationKeys.file(dataValueParams),
         dataValueParams,
         mutationFn,
         optimisticUpdateFn: optimisticallySetFileDataValue,
@@ -98,11 +98,24 @@ export function useUploadFileDataValueMutation({ deId, cocId }) {
 /** The `mutate` function returned by this hook expects no arguments */
 export function useDeleteDataValueMutation({ deId, cocId }) {
     const dataValueParams = useDataValueParams({ deId, cocId })
-    const mutationFn = useDeleteDataValueMutationFunction(dataValueParams)
+    const mutationFn = useDeleteDataValueMutationFunction()
 
     return useSharedDataValueMutation({
+        mutationKey: mutationKeys.delete(dataValueParams),
         dataValueParams,
         mutationFn,
         optimisticUpdateFn: optimisticallyDeleteDataValue,
+    })
+}
+
+export function useSetDataValueMutationDefaults(queryClient) {
+    queryClient.setMutationDefaults(mutationKeys.file(), {
+        mutationFn: useUploadFileDataValueMutationFunction(),
+    })
+    queryClient.setMutationDefaults(mutationKeys.update(), {
+        mutationFn: useSetDataValueMutationFunction(),
+    })
+    queryClient.setMutationDefaults(mutationKeys.delete(), {
+        mutationFn: useDeleteDataValueMutationFunction(),
     })
 }

--- a/src/data-workspace/data-value-mutations/index.js
+++ b/src/data-workspace/data-value-mutations/index.js
@@ -2,7 +2,7 @@ export {
     useSetDataValueMutation,
     useDeleteDataValueMutation,
     useUploadFileDataValueMutation,
-    useSetDataValueMutationDefaults,
 } from './data-value-mutations.js'
 export { useDataValueParams } from './use-data-value-params.js'
 export { mutationKeys } from './mutation-key-factory.js'
+export { setDataValueMutationDefaults } from './mutation-functions.js'

--- a/src/data-workspace/data-value-mutations/index.js
+++ b/src/data-workspace/data-value-mutations/index.js
@@ -5,5 +5,4 @@ export {
     useSetDataValueMutationDefaults,
 } from './data-value-mutations.js'
 export { useDataValueParams } from './use-data-value-params.js'
-export * from './mutation-functions.js'
 export { mutationKeys } from './mutation-key-factory.js'

--- a/src/data-workspace/data-value-mutations/index.js
+++ b/src/data-workspace/data-value-mutations/index.js
@@ -1,7 +1,9 @@
 export {
-    getDataValueMutationKey,
     useSetDataValueMutation,
     useDeleteDataValueMutation,
     useUploadFileDataValueMutation,
+    useSetDataValueMutationDefaults,
 } from './data-value-mutations.js'
 export { useDataValueParams } from './use-data-value-params.js'
+export * from './mutation-functions.js'
+export { mutationKeys } from './mutation-key-factory.js'

--- a/src/data-workspace/data-value-mutations/mutation-functions.js
+++ b/src/data-workspace/data-value-mutations/mutation-functions.js
@@ -32,7 +32,7 @@ const createSharedMutateFn = (engine, mutationObj) =>
     function mutateFn(variables) {
         // get params for the mutation (de, co, ds, cc, cp) from the
         // `mutationKey`, which is set in the mutation options object and can
-        // be accessed on `this` in the mutation function.
+        // be accessed via `this`-context in the mutation function.
         // This saves passing `dataValueParams` everywhere
         const { mutationKey } = this
         const { params } = mutationKey[1]

--- a/src/data-workspace/data-value-mutations/mutation-functions.js
+++ b/src/data-workspace/data-value-mutations/mutation-functions.js
@@ -80,13 +80,16 @@ export function useUploadFileDataValueMutationFunction() {
 }
 
 export function setDataValueMutationDefaults(queryClient, engine) {
-    queryClient.setMutationDefaults(mutationKeys.file(), {
-        mutationFn: createSharedMutateFn(engine, SET_DATA_VALUE_MUTATION),
-    })
     queryClient.setMutationDefaults(mutationKeys.update(), {
-        mutationFn: createSharedMutateFn(engine, UPLOAD_FILE_MUTATION),
-    })
-    queryClient.setMutationDefaults(mutationKeys.delete(), {
-        mutationFn: createSharedMutateFn(engine, DELETE_DATA_VALUE_MUTATION),
-    })
+        mutationFn: createSharedMutateFn(engine, SET_DATA_VALUE_MUTATION),
+    }),
+        queryClient.setMutationDefaults(mutationKeys.file(), {
+            mutationFn: createSharedMutateFn(engine, UPLOAD_FILE_MUTATION),
+        }),
+        queryClient.setMutationDefaults(mutationKeys.delete(), {
+            mutationFn: createSharedMutateFn(
+                engine,
+                DELETE_DATA_VALUE_MUTATION
+            ),
+        })
 }

--- a/src/data-workspace/data-value-mutations/mutation-functions.js
+++ b/src/data-workspace/data-value-mutations/mutation-functions.js
@@ -1,6 +1,6 @@
 import { useDataEngine } from '@dhis2/app-runtime'
 import { useMemo } from 'react'
-
+import { mutationKeys } from './mutation-key-factory.js'
 // Note: the generic `data` and `params` functions are used in these
 // mutation objects instead of destructuring each property because undefined
 // properties cause errors, and it's better to handle logic to include or
@@ -66,13 +66,27 @@ export function useSetDataValueMutationFunction() {
         mutationObj: SET_DATA_VALUE_MUTATION,
     })
 }
+
 export function useDeleteDataValueMutationFunction() {
     return useSharedMutationFunction({
         mutationObj: DELETE_DATA_VALUE_MUTATION,
     })
 }
+
 export function useUploadFileDataValueMutationFunction() {
     return useSharedMutationFunction({
         mutationObj: UPLOAD_FILE_MUTATION,
+    })
+}
+
+export function setDataValueMutationDefaults(queryClient, engine) {
+    queryClient.setMutationDefaults(mutationKeys.file(), {
+        mutationFn: createSharedMutateFn(engine, SET_DATA_VALUE_MUTATION),
+    })
+    queryClient.setMutationDefaults(mutationKeys.update(), {
+        mutationFn: createSharedMutateFn(engine, UPLOAD_FILE_MUTATION),
+    })
+    queryClient.setMutationDefaults(mutationKeys.delete(), {
+        mutationFn: createSharedMutateFn(engine, DELETE_DATA_VALUE_MUTATION),
     })
 }

--- a/src/data-workspace/data-value-mutations/mutation-functions.js
+++ b/src/data-workspace/data-value-mutations/mutation-functions.js
@@ -28,10 +28,13 @@ const UPLOAD_FILE_MUTATION = {
     data: (data) => data,
 }
 
-export const createSharedMutateFn = (engine, mutationObj) =>
+const createSharedMutateFn = (engine, mutationObj) =>
     function mutateFn(variables) {
+        // get params for the mutation (de, co, ds, cc, cp) from the
+        // `mutationKey`, which is set in the mutation options object and can
+        // be accessed on `this` in the mutation function.
+        // This saves passing `dataValueParams` everywhere
         const { mutationKey } = this
-        // gather params from mutationKey
         const { params } = mutationKey[1]
         return engine.mutate(mutationObj, {
             variables: { ...params, ...variables },

--- a/src/data-workspace/data-value-mutations/mutation-key-factory.js
+++ b/src/data-workspace/data-value-mutations/mutation-key-factory.js
@@ -10,6 +10,21 @@ const createSubKey = (subScope) => (params) => {
     return [...rootKey, { ...theState }]
 }
 
+/**
+ * MutationKeys for dataValues.
+ * These are all functions that can be called with the dataValueParams
+ * to narrow down the mutation
+ *
+ * Example keys:
+ *   mutationKeys.all() ==> ['dataValues']
+ *   mutationKeys.update(dvParams)
+ *      ==> ['dataValues', { method: 'update', params: dvParams }]
+ *   mutationKeys.file(dvParams)
+ *      ==> ['dataValues', { method: 'update', entity: 'file', params: dvParams }]
+ *   mutationKeys.delete() ==> ['dataValues', { method: 'delete' }]
+ * etc.
+ *
+ */
 export const mutationKeys = {
     all: createSubKey(),
     update: createSubKey({ method: 'update' }),

--- a/src/data-workspace/data-value-mutations/mutation-key-factory.js
+++ b/src/data-workspace/data-value-mutations/mutation-key-factory.js
@@ -1,0 +1,18 @@
+const rootKey = ['dataValues']
+
+const createSubKey = (subScope) => (params) => {
+    const theState = {
+        ...subScope,
+    }
+    if (params) {
+        theState.params = params
+    }
+    return [...rootKey, { ...theState }]
+}
+
+export const mutationKeys = {
+    all: createSubKey(),
+    update: createSubKey({ method: 'update' }),
+    file: createSubKey({ method: 'update', entity: 'file' }),
+    delete: createSubKey({ method: 'delete' }),
+}

--- a/src/data-workspace/data-value-mutations/mutation-key-factory.js
+++ b/src/data-workspace/data-value-mutations/mutation-key-factory.js
@@ -1,14 +1,14 @@
-const rootKey = ['dataValues']
-
-const createSubKey = (subScope) => (params) => {
-    const theState = {
-        ...subScope,
+const createMutationKey =
+    ([rootKey, subScope]) =>
+    (params) => {
+        const mergedState = {
+            ...subScope,
+        }
+        if (params) {
+            mergedState.params = params
+        }
+        return [...rootKey, { ...mergedState }]
     }
-    if (params) {
-        theState.params = params
-    }
-    return [...rootKey, { ...theState }]
-}
 
 /**
  * MutationKeys for dataValues.
@@ -24,10 +24,16 @@ const createSubKey = (subScope) => (params) => {
  *   mutationKeys.delete() ==> ['dataValues', { method: 'delete' }]
  * etc.
  *
- */
+ * ['dataValues, { method: update }] will match all keys with update. Eg, even
+    ['dataValues, { method: update, entity: 'file' }]
+    When checking for active mutation (useIsMutating) you can match based on ‘update’
+    and mutations for file will be included in the match
+*/
+
+const rootKey = ['dataValues']
 export const mutationKeys = {
-    all: createSubKey(),
-    update: createSubKey({ method: 'update' }),
-    file: createSubKey({ method: 'update', entity: 'file' }),
-    delete: createSubKey({ method: 'delete' }),
+    all: createMutationKey([rootKey]),
+    update: createMutationKey([rootKey, { method: 'update' }]),
+    file: createMutationKey([rootKey, { method: 'update', entity: 'file' }]),
+    delete: createMutationKey([rootKey, { method: 'delete' }]),
 }


### PR DESCRIPTION
[TECH-1356](https://dhis2.atlassian.net/browse/TECH-1394)
Also fixes [TECH-1393](https://dhis2.atlassian.net/browse/TECH-1393)

We didn't `resumePausedMutations` after they were hydrated from the store, so we lost those values after the user reloaded the app and went online again.
This needed some additional changes, because the mutations are now not necessarily mounted - and thus each mutation needs a `mutationDefault` - that describes how to send that stored mutation (since the `mutateFn` themselves are not stored/serialized). 
One complication of that, is that the `mutateFn` did not have access to the `queryKey` (only the `variables` passed to mutate!). Which would make it so we would have to include the mutationKey params to all the variable-objects. However, after digging around I found that you have access to the `mutationKey` in the `this-context` of `mutateFn`. So we now 
leverage this to gather those params. Therefore I could also delete some the passing of those variables to the hooks. 

Also introduced a new structure for the `mutationKeys`. See [this blog post](https://tkdodo.eu/blog/leveraging-the-query-function-context#object-query-keys) for where I got the inspiration from. However, the reason to do this was that the `defaultMutations` needs different `mutateFn` for `update`, `delete` and `uploadFile` requests. The cleanest way to do this is to separate this into different `mutationKeys` - since they are not the same mutation! 

A cool bonus is that file uploads work out of the box while offline across reloads! Since we are using indexed-db, it's able to store the file object with the data, while you would normally have to serialize the file-data manually. 