### PR TITLE
fix: deduplicate identical mutations

### DIFF
--- a/src/app/query-client/use-query-client.js
+++ b/src/app/query-client/use-query-client.js
@@ -25,6 +25,25 @@ const useQueryClient = () => {
         },
     })
 
+    const mutationCache = queryClient.getMutationCache()
+    // prevent duplicate mutations from being stored in cache
+    mutationCache.subscribe((event) => {
+        if (event.type !== 'updated') {
+            return
+        }
+        const { mutation } = event
+        const duplicateMutation = mutationCache.find({
+            mutationKey: mutation.options.mutationKey,
+            // ensure previous mutation was fired before this
+            // (mutationId is an incremental integer)
+            predicate: (currMutation) =>
+                currMutation.mutationId < mutation.mutationId,
+        })
+        if (duplicateMutation) {
+            mutationCache.remove(duplicateMutation)
+        }
+    })
+
     return queryClient
 }
 


### PR DESCRIPTION

**NOTE**: This is a proof of concept. This does introduce bugs!

Eg. changing comments when offline, then changing value (or any other order) - will result in only the last action happening.
It's probably an easy fix once we use queryKeys properly, and can update individual values easily. 