### PR TITLE
fix(use-data-value-set): add a hook to get dv-data with selector

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-09-07T10:30:31.473Z\n"
-"PO-Revision-Date: 2022-09-07T10:30:31.473Z\n"
+"POT-Creation-Date: 2022-09-11T14:24:30.880Z\n"
+"PO-Revision-Date: 2022-09-11T14:24:30.880Z\n"
 
 msgid "Not authorized"
 msgstr "Not authorized"
@@ -218,6 +218,9 @@ msgstr "Code: {{code}}"
 msgid "ID: {{id}}"
 msgstr "ID: {{id}}"
 
+msgid "Description: {{description}}"
+msgstr "Description: {{description}}"
+
 msgid "Last updated {{- timeAgo}} by {{- name}}"
 msgstr "Last updated {{- timeAgo}} by {{- name}}"
 
@@ -318,6 +321,18 @@ msgid ""
 msgstr ""
 "There are no Data Elements in this data set. Adds some Data Elements to use "
 "this data set."
+
+msgid "Data cannot be added or changed outside of the data input period."
+msgstr "Data cannot be added or changed outside of the data input period."
+
+msgid "Data cannot be added or changed because data entry has concluded."
+msgstr "Data cannot be added or changed because data entry has concluded."
+
+msgid "Data cannot be added or changed because data has been approved."
+msgstr "Data cannot be added or changed because data has been approved."
+
+msgid "Data set locked"
+msgstr "Data set locked"
 
 msgid "Filter fields in all sections"
 msgstr "Filter fields in all sections"

--- a/src/data-workspace/data-entry-cell/entry-field-input.js
+++ b/src/data-workspace/data-entry-cell/entry-field-input.js
@@ -65,7 +65,6 @@ export function EntryFieldInput({
     locked,
 }) {
     const setHighlightedFieldId = useSetHighlightedFieldIdContext()
-
     // used so we don't consume the "id" which
     // would cause this component to rerender
     const setRightHandPanel = useSetRightHandPanel()

--- a/src/data-workspace/data-workspace.js
+++ b/src/data-workspace/data-workspace.js
@@ -105,7 +105,6 @@ export const DataWorkspace = ({ selectionHasNoFormMessage }) => {
                     >
                         <MutationIndicator />
                     </div>
-
                     <BottomBar />
                 </footer>
             </div>

--- a/src/data-workspace/use-min-max-limits.js
+++ b/src/data-workspace/use-min-max-limits.js
@@ -1,16 +1,18 @@
-import { useDataValueSet, useOrgUnitId } from '../shared/index.js'
+import { useCallback } from 'react'
+import { useDataValuesWithSelector } from '../shared/index.js'
 
 export const useMinMaxLimits = (dataElementId, categoryOptionComboId) => {
-    const [orgUnitId] = useOrgUnitId()
-    const dataValueSet = useDataValueSet()
-
-    const limits = dataValueSet.data?.minMaxValues.find((minMaxValue) => {
-        return (
-            minMaxValue.categoryOptionCombo === categoryOptionComboId &&
-            minMaxValue.dataElement === dataElementId &&
-            minMaxValue.orgUnit === orgUnitId
-        )
-    })
+    const selector = useCallback(
+        (data) =>
+            data.minMaxValues?.find((minMaxValue) => {
+                return (
+                    minMaxValue.categoryOptionCombo === categoryOptionComboId &&
+                    minMaxValue.dataElement === dataElementId
+                )
+            }),
+        [dataElementId, categoryOptionComboId]
+    )
+    const limits = useDataValuesWithSelector(selector)
 
     return {
         min: limits?.minValue,

--- a/src/shared/use-data-value-set/index.js
+++ b/src/shared/use-data-value-set/index.js
@@ -1,2 +1,6 @@
 export { default as useDataValueSetQueryKey } from './use-data-value-set-query-key.js'
-export { useDataValueSet } from './use-data-value-set.js'
+export {
+    useDataValueSet,
+    useSingleDataValue,
+    useDataValuesWithSelector,
+} from './use-data-value-set.js'

--- a/src/shared/use-data-value-set/use-data-value-set.js
+++ b/src/shared/use-data-value-set/use-data-value-set.js
@@ -1,8 +1,8 @@
 import { useQuery, useIsMutating } from '@tanstack/react-query'
+import { useCallback } from 'react'
 import { createSelector } from 'reselect'
 import { useIsValidSelection } from '../use-context-selection/index.js'
 import useDataValueSetQueryKey from './use-data-value-set-query-key.js'
-
 // Form value object structure: { [dataElementId]: { [cocId]: value } }
 function mapDataValuesToFormInitialValues(dataValues) {
     // It's possible for the backend to return a response
@@ -46,13 +46,28 @@ function mapDataValuesToFormInitialValues(dataValues) {
     return formInitialValues
 }
 
-const select = createSelector(
+const selectDataValues = createSelector(
     (data) => data,
     (data) => {
         const dataValues = mapDataValuesToFormInitialValues(data.dataValues)
         const minMaxValues = data.minMaxValues || {}
         const lockStatus = data.lockStatus || ''
         return { dataValues, minMaxValues, lockStatus }
+    }
+)
+
+const selectSingleDataValue = createSelector(
+    (data) => data,
+    (_, { dataElementId, categoryOptionComboId }) => ({
+        dataElementId,
+        categoryOptionComboId,
+    }),
+    (data, { dataElementId, categoryOptionComboId }) => {
+        return data.dataValues?.find(
+            (dv) =>
+                dv.dataElement === dataElementId &&
+                dv.categoryOptionCombo === categoryOptionComboId
+        )
     }
 )
 
@@ -70,7 +85,10 @@ const select = createSelector(
  *
  * TODO: This is no longer using the dataValueSet endpoint; should rename.
  */
-export const useDataValueSet = ({ onSuccess } = {}) => {
+export const useDataValueSet = ({
+    onSuccess,
+    select = selectDataValues,
+} = {}) => {
     const isValidSelection = useIsValidSelection()
     const queryKey = useDataValueSetQueryKey()
     const activeMutations = useIsMutating({ mutationKey: ['dataValues'] })
@@ -79,7 +97,7 @@ export const useDataValueSet = ({ onSuccess } = {}) => {
         // Only enable this query if there are no ongoing mutations
         // TODO: Disable if disconnected from DHIS2 server?
         enabled: activeMutations === 0 && isValidSelection,
-        select: select,
+        select,
         // Fetch once, no matter the network connectivity;
         // will be 'paused' if offline and the request fails.
         // Important to try the network when on offline/local DHIS2 implmnt'ns
@@ -89,11 +107,42 @@ export const useDataValueSet = ({ onSuccess } = {}) => {
             // this should only happen during initial app-load.
             // If we were to return 'false' the query would not be refetch on first mount
             // because it's mounted with hydrated-state
-            return !!query.meta.isHydrated
+            return !!query.meta?.isHydrated
         },
         meta: { persist: true },
         onSuccess,
     })
 
     return result
+}
+
+export const useDataValuesWithSelector = (selector) => {
+    // note we cannot re-use useDataValueSet() above due to additional re-renders from useIsMutating()
+    const queryKey = useDataValueSetQueryKey()
+    // this query should always be called after dataValue is loaded by hook above
+    // Since this uses the cache only.
+    // The reason for this is that we do not want calls to this to refetch or
+    // trigger cache-updates (without meta.persist=true)
+    const { data } = useQuery(queryKey, {
+        // disable fetching of query, is handled by useDataValueSet above
+        enabled: false,
+        select: selector,
+    })
+    return data
+}
+
+export const useSingleDataValue = ({
+    dataElementId,
+    categoryOptionComboId,
+}) => {
+    const select = useCallback(
+        (data) => {
+            return selectSingleDataValue(data, {
+                dataElementId,
+                categoryOptionComboId,
+            })
+        },
+        [dataElementId, categoryOptionComboId]
+    )
+    return useDataValuesWithSelector(select)
 }


### PR DESCRIPTION
A solution for `minMaxValue`-rerenders, and a way to only subscribe to a single value from the `useQuery`. Was the solution for subscribing to a single value just infront of us all this time, and we just didn't know that `select` would only subscribe to what was returned? Kind of, but it has big performance issues by itself. 

It's interesting to me that this functionality is barely mentioned in a secondary sentence in [this blog post](https://tkdodo.eu/blog/react-query-data-transformations#3-using-the-select-option). I've researched a lot, and never seen a mention of that functionality in select. 

This seemed like it would be the perfect solution, but the app "freezes" for 1-2seconds when posting a value. Seems like the algorithm they're using to check if the value changes is not very efficient. I've also tried setting `structuralSharing: false`, as I've read this can cause performance issues, but didn't make much of a difference. This prevent re-rendering of all fields, but the app still stutters when a value is synced.

Anyway, I would prefer the [zustand solution](https://github.com/dhis2/data-entry-app/pull/153), since the performance using that is a lot better. I just wanted to show that this is possible, and we might want to investigate if we could get this to work instead - and it could potentially be useful for a few components, but seems like rendering this in every field in a big form (Child Health) causes a lot of stuttering when changing a value (after value is successfully synced).

 
