### PR TITLE
fix: prevent refetch after post

### DIFF
--- a/src/app/query-client/configured-query-client-provider.js
+++ b/src/app/query-client/configured-query-client-provider.js
@@ -39,6 +39,7 @@ export const ConfiguredQueryClientProvider = ({ queryClient, children }) => {
             persistOptions={persistOptions}
             onSuccess={() => {
                 queryClient.resumePausedMutations()
+                queryClient.invalidateQueries()
             }}
         >
             {children}

--- a/src/shared/use-data-value-set/use-data-value-set-query-key.js
+++ b/src/shared/use-data-value-set/use-data-value-set-query-key.js
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useApiAttributeParams } from '../use-api-attribute-params.js'
 import { useContextSelection } from '../use-context-selection/index.js'
 import { dataValueSets } from './query-key-factory.js'
@@ -10,11 +11,15 @@ export default function useDataValueSetQueryKey() {
         attributeOptions: categoryOptionIds,
     } = useApiAttributeParams()
 
-    return dataValueSets.byIds({
-        dataSetId,
-        periodId,
-        orgUnitId,
-        categoryComboId,
-        categoryOptionIds,
-    })
+    return useMemo(
+        () =>
+            dataValueSets.byIds({
+                dataSetId,
+                periodId,
+                orgUnitId,
+                categoryComboId,
+                categoryOptionIds,
+            }),
+        [dataSetId, orgUnitId, periodId, categoryComboId, categoryOptionIds]
+    )
 }


### PR DESCRIPTION
Adding the `staleTime` is the real fix. Adding `useMemo` to the `useDataValueSetQueryKey` doesn't really fix anything, but could prevent issues in the future since having a stable query key for a single selection makes sense.