### PR TITLE
chore: conditionally render devtools and ignore local env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ src/locales
 build
 cypress.env.json
 .vscode
+.env.development.local
+.env.test.local
+.env.production.local

--- a/src/app/app-wrapper.js
+++ b/src/app/app-wrapper.js
@@ -17,6 +17,8 @@ import App from './app.js'
 import { ConfiguredQueryClientProvider } from './query-client/configured-query-client-provider.js'
 import useQueryClient from './query-client/use-query-client.js'
 
+const enableRQDevtools = process.env.REACT_APP_ENABLE_RQ_DEVTOOLS === 'true'
+
 /**
  * @param {Object} props
  * @param {QueryClient} props.queryClient
@@ -36,12 +38,13 @@ export function OuterComponents({
     router: Router,
     queryClient,
 }) {
+    console.log(process.env)
     return (
         <>
             <CssReset />
             <CssVariables colors spacers theme />
             <ConfiguredQueryClientProvider queryClient={queryClient}>
-                <ReactQueryDevtools />
+                {enableRQDevtools && <ReactQueryDevtools />}
                 <Router>
                     <QueryParamProvider ReactRouterRoute={Route}>
                         <LockedProvider>


### PR DESCRIPTION
React Query dev tools are now **disabled** by default. If you set the `REACT_APP_ENABLE_RQ_DEVTOOLS`env variable to true, they will be **enabled**:

To have them temporarely enabled, it is recommended to start the app like this:
```bash
REACT_APP_ENABLE_RQ_DEVTOOLS=true yarn start
```

To have them permanently enabled, please add the following line to a `.env.development.local` file:
```bash
REACT_APP_ENABLE_RQ_DEVTOOLS=true
```