### PR TITLE
feat(bottom-bar): count number of form-errors

### DIFF
--- a/src/bottom-bar/main-tool-bar.js
+++ b/src/bottom-bar/main-tool-bar.js
@@ -5,7 +5,11 @@ import cx from 'classnames'
 import React from 'react'
 import { validationResultsSidebarId } from '../data-workspace/constants.js'
 import useRightHandPanelContext from '../right-hand-panel/use-right-hand-panel-context.js'
-import { useDataValueSetQueryKey, useLockedContext } from '../shared/index.js'
+import {
+    useDataValueSetQueryKey,
+    useLockedContext,
+    useEntryFormStore,
+} from '../shared/index.js'
 import styles from './main-tool-bar.module.css'
 
 export default function MainToolBar() {
@@ -15,6 +19,9 @@ export default function MainToolBar() {
     const activeMutations = useIsMutating({
         mutationKey: queryKey,
     })
+    const numberOfErrors = useEntryFormStore((state) =>
+        state.getNumberOfErrors()
+    )
 
     const validateDisabled = activeMutations > 0
 
@@ -50,15 +57,25 @@ export default function MainToolBar() {
                     : i18n.t('Mark complete')}
             </Button>
 
-            <button className={cx(styles.goToInvalidValue, styles.toolbarItem)}>
-                <span className={cx(styles.icon, styles.goToInvalidValueIcon)}>
-                    <IconErrorFilled16 color={colors.red700} />
-                </span>
-
-                <span className={styles.goToInvalidValueLabel}>
-                    {i18n.t('3 invalid values not saved')}
-                </span>
-            </button>
+            {numberOfErrors > 0 && (
+                <button
+                    className={cx(styles.goToInvalidValue, styles.toolbarItem)}
+                >
+                    <span
+                        className={cx(styles.icon, styles.goToInvalidValueIcon)}
+                    >
+                        <IconErrorFilled16 color={colors.red700} />
+                    </span>
+                    <span className={styles.goToInvalidValueLabel}>
+                        {numberOfErrors === 1
+                            ? i18n.t('1 invalid value not saved')
+                            : i18n.t(
+                                  '{{numberOfErrors}} invalid values not saved',
+                                  { numberOfErrors }
+                              )}
+                    </span>
+                </button>
+            )}
 
             {isComplete && (
                 <span

--- a/src/data-workspace/entry-form.js
+++ b/src/data-workspace/entry-form.js
@@ -8,6 +8,7 @@ import {
     LockedStates,
     useFormChangedSincePanelOpenedContext,
     useLockedContext,
+    useEntryFormStore,
 } from '../shared/index.js'
 import { FORM_TYPES } from './constants.js'
 import { CustomForm } from './custom-form/index.js'
@@ -40,8 +41,11 @@ export const EntryForm = React.memo(function EntryForm({ dataSet }) {
     const rightHandPanelContext = useRightHandPanelContext()
     const { locked, lockStatus } = useLockedContext()
     const formType = dataSet.formType
+    const setEntryFormStore = useEntryFormStore((state) => state.setErrors)
+
     useFormState({
         onChange: (formState) => {
+            setEntryFormStore(formState.errors)
             // set formChanged when the form is dirty and the right hand panel is open
             // components in the right hand panel will reset the formChanged state to false
             if (formState.dirty && rightHandPanelContext.id) {
@@ -50,6 +54,7 @@ export const EntryForm = React.memo(function EntryForm({ dataSet }) {
         },
         subscription: {
             dirty: true,
+            errors: true,
         },
     })
 

--- a/src/data-workspace/entry-form.js
+++ b/src/data-workspace/entry-form.js
@@ -41,11 +41,11 @@ export const EntryForm = React.memo(function EntryForm({ dataSet }) {
     const rightHandPanelContext = useRightHandPanelContext()
     const { locked, lockStatus } = useLockedContext()
     const formType = dataSet.formType
-    const setEntryFormStore = useEntryFormStore((state) => state.setErrors)
+    const setFormErrors = useEntryFormStore((state) => state.setErrors)
 
     useFormState({
         onChange: (formState) => {
-            setEntryFormStore(formState.errors)
+            setFormErrors(formState.errors)
             // set formChanged when the form is dirty and the right hand panel is open
             // components in the right hand panel will reset the formChanged state to false
             if (formState.dirty && rightHandPanelContext.id) {

--- a/src/shared/stores/entry-form-store.js
+++ b/src/shared/stores/entry-form-store.js
@@ -1,0 +1,24 @@
+import create from 'zustand'
+
+const inititalState = {
+    errors: {},
+}
+
+export const useEntryFormStore = create((set, get) => ({
+    ...inititalState,
+    setErrors: (errors) => set({ errors: errors ?? {} }),
+    getErrors: () => get().errors,
+    getNumberOfErrors: () => countLeaves(get().getErrors()),
+}))
+
+function countLeaves(object) {
+    // base case
+    if (Array.isArray(object) || typeof object !== 'object') {
+        return 1
+    } else {
+        return Object.values(object).reduce(
+            (acc, curr) => acc + countLeaves(curr),
+            0
+        )
+    }
+}

--- a/src/shared/stores/entry-form-store.js
+++ b/src/shared/stores/entry-form-store.js
@@ -11,6 +11,12 @@ export const useEntryFormStore = create((set, get) => ({
     getNumberOfErrors: () => countLeaves(get().getErrors()),
 }))
 
+// errors object is the same shape as form-Values
+// eg. { [dataElementId] : {
+//         [categoryOptionComboId]: "error message"
+//       }
+//     }
+// so we just count the number of leaves in the object to get number of errors
 function countLeaves(object) {
     // base case
     if (Array.isArray(object) || typeof object !== 'object') {

--- a/src/shared/stores/index.js
+++ b/src/shared/stores/index.js
@@ -1,1 +1,2 @@
 export { useValueStore } from './data-value-store.js'
+export { useEntryFormStore } from './entry-form-store.js'


### PR DESCRIPTION
Fixes [TECH-1405](https://dhis2.atlassian.net/browse/TECH-1405)

Pretty simple implementation, with a entryForm zustand-store. Another approach would be to share the `form`-ref in a context, like @HendrikThePendric proposed earlier. Or we could just put it in the same zustand-store. Not sure what you think is best. 
Sharing form-ref could be beneficial if we eg. want to focus the first errored-field when the user clicks on the "Invalid"-icon or something?