### PR TITLE
fix(contextual-help): update css-selectors

### DIFF
--- a/src/context-selection/contextual-help-sidebar/cell.module.css
+++ b/src/context-selection/contextual-help-sidebar/cell.module.css
@@ -15,11 +15,11 @@
 }
 
 .inputInvalid {
-    composes: inputInvalid from '../../data-workspace/data-entry-cell/data-entry-cell.module.css';
+    composes: invalid from '../../data-workspace/data-entry-cell/data-entry-cell.module.css';
 }
 
 .inputSynced {
-    composes: inputSynced from '../../data-workspace/data-entry-cell/data-entry-cell.module.css';
+    composes: synced from '../../data-workspace/data-entry-cell/data-entry-cell.module.css';
 }
 
 .topRightIndicator {


### PR DESCRIPTION
"Synced" and "invalid" helper-cells has been refactored a time ago, and was not updated with the new selector-names. So they were missing their background-css.