### PR TITLE
fix: fix some offline issues

### DIFF
--- a/src/app/app-wrapper.js
+++ b/src/app/app-wrapper.js
@@ -17,7 +17,7 @@ import App from './app.js'
 import { ConfiguredQueryClientProvider } from './query-client/configured-query-client-provider.js'
 import useQueryClient from './query-client/use-query-client.js'
 
-const enableRQDevtools = process.env.REACT_APP_ENABLE_RQ_DEVTOOLS === 'true'
+const enableRQDevtools = true //process.env.REACT_APP_ENABLE_RQ_DEVTOOLS === 'true'
 
 /**
  * @param {Object} props

--- a/src/app/query-client/configured-query-client-provider.js
+++ b/src/app/query-client/configured-query-client-provider.js
@@ -38,9 +38,7 @@ export const ConfiguredQueryClientProvider = ({ queryClient, children }) => {
             client={queryClient}
             persistOptions={persistOptions}
             onSuccess={() => {
-                queryClient
-                    .resumePausedMutations()
-                    .then(() => queryClient.invalidateQueries())
+                queryClient.resumePausedMutations()
             }}
         >
             {children}

--- a/src/app/query-client/configured-query-client-provider.js
+++ b/src/app/query-client/configured-query-client-provider.js
@@ -38,7 +38,9 @@ export const ConfiguredQueryClientProvider = ({ queryClient, children }) => {
             client={queryClient}
             persistOptions={persistOptions}
             onSuccess={() => {
-                queryClient.resumePausedMutations()
+                queryClient
+                    .resumePausedMutations()
+                    .then(() => queryClient.invalidateQueries())
             }}
         >
             {children}

--- a/src/data-workspace/data-value-mutations/mutation-functions.js
+++ b/src/data-workspace/data-value-mutations/mutation-functions.js
@@ -80,16 +80,13 @@ export function useUploadFileDataValueMutationFunction() {
 }
 
 export function setDataValueMutationDefaults(queryClient, engine) {
+    queryClient.setMutationDefaults(mutationKeys.file(), {
+        mutationFn: createSharedMutateFn(engine, UPLOAD_FILE_MUTATION),
+    })
     queryClient.setMutationDefaults(mutationKeys.update(), {
         mutationFn: createSharedMutateFn(engine, SET_DATA_VALUE_MUTATION),
-    }),
-        queryClient.setMutationDefaults(mutationKeys.file(), {
-            mutationFn: createSharedMutateFn(engine, UPLOAD_FILE_MUTATION),
-        }),
-        queryClient.setMutationDefaults(mutationKeys.delete(), {
-            mutationFn: createSharedMutateFn(
-                engine,
-                DELETE_DATA_VALUE_MUTATION
-            ),
-        })
+    })
+    queryClient.setMutationDefaults(mutationKeys.delete(), {
+        mutationFn: createSharedMutateFn(engine, DELETE_DATA_VALUE_MUTATION),
+    })
 }

--- a/src/shared/use-data-value-set/use-data-value-set.js
+++ b/src/shared/use-data-value-set/use-data-value-set.js
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { createSelector } from 'reselect'
 import { useIsValidSelection } from '../use-context-selection/index.js'
 import useDataValueSetQueryKey from './use-data-value-set-query-key.js'
@@ -73,10 +73,11 @@ const select = createSelector(
 export const useDataValueSet = ({ onSuccess } = {}) => {
     const isValidSelection = useIsValidSelection()
     const queryKey = useDataValueSetQueryKey()
+    const queryClient = useQueryClient()
 
     const result = useQuery(queryKey, {
         // TODO: Disable if disconnected from DHIS2 server?
-        enabled: isValidSelection,
+        enabled: !queryClient.isMutating() && isValidSelection,
         select: select,
         // Fetch once, no matter the network connectivity;
         // will be 'paused' if offline and the request fails.


### PR DESCRIPTION
Fixes a regression in #159 .

DataValues would be fetched before mutations are sent if doing this:
Go Offline -> Edit values -> reload app -> Go online.

This can cause problems, since the cache would update with the old values from the server, and not update again after.
This is basically doing the same thing as before that fix - but now we are using the `queryClient.isMutating` - which won't subscribe and re-render the hook, and thus prevent fetching after every value-change.

Also the order of `setMutationDefaults` seem to matter, so it seems that `mutationKeys.file()` must be applied before the more generic `update()`, or else the file would be sent with the `update()`-mutationObject.