### PR TITLE
fix: highlighted cell synced background

### DIFF
--- a/src/data-workspace/data-entry-cell/data-entry-cell.module.css
+++ b/src/data-workspace/data-entry-cell/data-entry-cell.module.css
@@ -24,6 +24,10 @@
     outline: 1px solid #a0adba;
 }
 
+.active {
+    background-color: #fff !important;
+}
+
 .highlighted {
     outline: 3px solid var(--colors-grey800) !important;
     border: none !important;
@@ -31,6 +35,7 @@
     /* Fix to prevent bottom outline to be clipped by next cell*/
     z-index: 1;
 }
+
 
 .highlighted.active {
     outline-color: var(--theme-focus) !important;
@@ -40,10 +45,11 @@
     background: var(--colors-grey300);
 }
 
-.invalid:not(.highlighted) {
+.invalid:not(.active) {
     background: var(--colors-red200);
-    outline: 1px solid var(--colors-red600) !important;
+    outline: 1px solid var(--colors-red600);
 }
+
 .invalid:hover {
     background: #ffb3bc;
 }

--- a/src/data-workspace/data-entry-cell/data-entry-cell.module.css
+++ b/src/data-workspace/data-entry-cell/data-entry-cell.module.css
@@ -31,8 +31,7 @@
 .highlighted {
     outline: 3px solid var(--colors-grey800) !important;
     border: none !important;
-    background: #fff;
-    /* Fix to prevent bottom outline to be clipped by next cell*/
+    /* Fix to prevent bottom outline to be clipped by next cell */
     z-index: 1;
 }
 

--- a/src/data-workspace/data-entry-cell/data-entry-cell.module.css
+++ b/src/data-workspace/data-entry-cell/data-entry-cell.module.css
@@ -27,7 +27,9 @@
 .highlighted {
     outline: 3px solid var(--colors-grey800) !important;
     border: none !important;
-    background: #fff !important;
+    background: #fff;
+    /* Fix to prevent bottom outline to be clipped by next cell*/
+    z-index: 1;
 }
 
 .highlighted.active {


### PR DESCRIPTION
Fixes some styling issues with highlighted field. Previously, the `!important` keyword on highlighted-field prevented `invalid` and `synced` styles from being applied to the highlighted field when this was unfocused.
I think we want the `white`-background when editing the field - and this is now done by using the `.active`-selector, which is in my opinion more correct than using the `highlighted-field`-selector.

Highlighted-synced unfocused:

![image](https://user-images.githubusercontent.com/13852438/190964978-59e09797-34fc-4a90-a01b-d381f82d23c1.png)

Before: 
![image](https://user-images.githubusercontent.com/13852438/190965127-9c358f2f-d711-4fa0-b519-4881ad6ca4b6.png)


Highlighted-synced focused:
(same as before)
![image](https://user-images.githubusercontent.com/13852438/190965032-02243079-1d4e-42be-b071-617510550b21.png)

Highlighted-error unfocused:

![image](https://user-images.githubusercontent.com/13852438/190965334-71e7ab09-36a8-4953-b0d9-6b92fd47a284.png)


Before:
![image](https://user-images.githubusercontent.com/13852438/190965238-03547174-2de8-4239-8494-cbbc0c251ffc.png)
