### PR TITLE
fix(comment-indicator): use correct parameter

### DIFF
--- a/src/shared/stores/data-value-store.js
+++ b/src/shared/stores/data-value-store.js
@@ -9,8 +9,10 @@ const inititalState = {
 
 export const useValueStore = create((set, get) => ({
     ...inititalState,
-    getDataValue: ({ dataElementId, cocId }) => {
-        return get().dataValueSet.dataValues?.[dataElementId]?.[cocId]
+    getDataValue: ({ dataElementId, categoryOptionComboId }) => {
+        return get().dataValueSet.dataValues?.[dataElementId]?.[
+            categoryOptionComboId
+        ]
     },
 
     getDataValues: () => get().dataValueSet?.dataValues,


### PR DESCRIPTION
Fixes [Tech-1424](https://dhis2.atlassian.net/browse/TECH-1424)

Might've been introduced in a bad merge-conflict, but we were using the wrong parameter-name. 