### PR TITLE
fix(update-min-max): only show error message after submit failed

### DIFF
--- a/src/data-workspace/data-details-sidebar/limits-form-wrapper.js
+++ b/src/data-workspace/data-details-sidebar/limits-form-wrapper.js
@@ -1,5 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
-import { composeValidators } from '@dhis2/ui-forms'
+import { composeValidators, hasValue } from '@dhis2/ui-forms'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Form } from 'react-final-form'
@@ -29,11 +28,7 @@ export default function LimitsFormWrapper({
 
     const validator = minMaxValidatorsByValueType[valueType]
     const validateMin = composeValidators(
-        (value, values) => {
-            if (!value && !!values.max) {
-                return i18n.t('A min is required when providing a max')
-            }
-        },
+        hasValue,
         validator,
         createLessThan('max', limitInputLabelsByName.max)
     )
@@ -41,11 +36,7 @@ export default function LimitsFormWrapper({
     // No need to check whether this is really more
     // than "min" as "min" is already checking
     // whether it's less than "max"
-    const validateMax = composeValidators((value, values) => {
-        if (!value && !!values.min) {
-            return i18n.t('A max is required when providing a min')
-        }
-    }, validator)
+    const validateMax = composeValidators(hasValue, validator)
 
     const validate = (values) => {
         let errors = undefined

--- a/src/data-workspace/data-details-sidebar/limits-input.js
+++ b/src/data-workspace/data-details-sidebar/limits-input.js
@@ -2,13 +2,20 @@ import { Box, Field, Input } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styles from './limits-input.module.css'
-
 // @TODO: Talk to @joe about this
 // Not using the `InputField` component from @dhis2/ui
 // because that one always shows the error.
 // In this case we want to show the errors below the entire form,
 // otherwise the text has very limited space
-export default function LimitsInput({ label, name, onChange, value, error }) {
+export default function LimitsInput({
+    label,
+    name,
+    onChange,
+    onFocus,
+    onBlur,
+    value,
+    error,
+}) {
     return (
         <Field label={label} name={name} className={styles.container}>
             <Box>
@@ -18,6 +25,8 @@ export default function LimitsInput({ label, name, onChange, value, error }) {
                     name={name}
                     value={value || ''}
                     error={error}
+                    onFocus={onFocus}
+                    onBlur={onBlur}
                 />
             </Box>
         </Field>
@@ -29,5 +38,7 @@ LimitsInput.propTypes = {
     label: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     value: PropTypes.string.isRequired,
+    onBlur: PropTypes.func.isRequired,
     onChange: PropTypes.func.isRequired,
+    onFocus: PropTypes.func.isRequired,
 }

--- a/src/data-workspace/data-details-sidebar/limits-validation-error-message.js
+++ b/src/data-workspace/data-details-sidebar/limits-validation-error-message.js
@@ -3,14 +3,16 @@ import React from 'react'
 import limitInputLabelsByName from './limits-input-labels-by-name.js'
 import styles from './limits-validation-error-message.module.css'
 
-export default function LimitsValidationErrorMessage({ errors }) {
+export default function LimitsValidationErrorMessage({ errors, touched }) {
     if (!errors.min && !errors.max) {
         return null
     }
 
+    const errorMessages = Object.entries(errors).filter(([key]) => touched[key])
+
     return (
         <div className={styles.container}>
-            {Object.entries(errors).map(([name, errorMsg]) => (
+            {errorMessages.map(([name, errorMsg]) => (
                 <span key={name} className={styles.error}>
                     <span className={styles.errorLabel}>
                         {limitInputLabelsByName[name]}
@@ -25,4 +27,5 @@ export default function LimitsValidationErrorMessage({ errors }) {
 
 LimitsValidationErrorMessage.propTypes = {
     errors: PropTypes.object,
+    touched: PropTypes.object,
 }

--- a/src/data-workspace/data-details-sidebar/limits-validation-error-message.js
+++ b/src/data-workspace/data-details-sidebar/limits-validation-error-message.js
@@ -3,16 +3,14 @@ import React from 'react'
 import limitInputLabelsByName from './limits-input-labels-by-name.js'
 import styles from './limits-validation-error-message.module.css'
 
-export default function LimitsValidationErrorMessage({ errors, touched }) {
+export default function LimitsValidationErrorMessage({ errors }) {
     if (!errors.min && !errors.max) {
         return null
     }
 
-    const errorMessages = Object.entries(errors).filter(([key]) => touched[key])
-
     return (
         <div className={styles.container}>
-            {errorMessages.map(([name, errorMsg]) => (
+            {Object.entries(errors).map(([name, errorMsg]) => (
                 <span key={name} className={styles.error}>
                     <span className={styles.errorLabel}>
                         {limitInputLabelsByName[name]}
@@ -27,5 +25,4 @@ export default function LimitsValidationErrorMessage({ errors, touched }) {
 
 LimitsValidationErrorMessage.propTypes = {
     errors: PropTypes.object,
-    touched: PropTypes.object,
 }

--- a/src/data-workspace/data-details-sidebar/update-limits.js
+++ b/src/data-workspace/data-details-sidebar/update-limits.js
@@ -19,7 +19,7 @@ function UpdateLimits({
     onCancel,
 }) {
     const form = useForm()
-    const { submitting, errors, touched } = form.getState()
+    const { submitting, submitFailed, errors } = form.getState()
 
     const minField = useField('min', {
         initialValue: limits.min,
@@ -46,8 +46,7 @@ function UpdateLimits({
                     <LimitsInput
                         {...minField.input}
                         label={limitInputLabelsByName.min}
-                        error={minField.meta.touched && !!minField.meta.error}
-                        meta={minField.meta}
+                        error={submitFailed && !!minField.meta.error}
                     />
 
                     <div className={styles.spaceBetween}></div>
@@ -55,13 +54,12 @@ function UpdateLimits({
                     <LimitsInput
                         {...maxField.input}
                         label={limitInputLabelsByName.max}
-                        error={maxField.meta.touched && !!maxField.meta.error}
-                        meta={maxField.meta}
+                        error={submitFailed && !!maxField.meta.error}
                     />
                 </div>
             </div>
 
-            <LimitsValidationErrorMessage errors={errors} touched={touched} />
+            {submitFailed && <LimitsValidationErrorMessage errors={errors} />}
 
             <ButtonStrip>
                 <Button small primary type="submit" loading={submitting}>

--- a/src/data-workspace/data-details-sidebar/update-limits.js
+++ b/src/data-workspace/data-details-sidebar/update-limits.js
@@ -19,7 +19,7 @@ function UpdateLimits({
     onCancel,
 }) {
     const form = useForm()
-    const { submitting, errors } = form.getState()
+    const { submitting, errors, touched } = form.getState()
 
     const minField = useField('min', {
         initialValue: limits.min,
@@ -46,7 +46,8 @@ function UpdateLimits({
                     <LimitsInput
                         {...minField.input}
                         label={limitInputLabelsByName.min}
-                        error={!!minField.meta.error}
+                        error={minField.meta.touched && !!minField.meta.error}
+                        meta={minField.meta}
                     />
 
                     <div className={styles.spaceBetween}></div>
@@ -54,23 +55,16 @@ function UpdateLimits({
                     <LimitsInput
                         {...maxField.input}
                         label={limitInputLabelsByName.max}
-                        error={!!maxField.meta.error}
+                        error={maxField.meta.touched && !!maxField.meta.error}
+                        meta={maxField.meta}
                     />
                 </div>
             </div>
 
-            <LimitsValidationErrorMessage errors={errors} />
+            <LimitsValidationErrorMessage errors={errors} touched={touched} />
 
             <ButtonStrip>
-                <Button
-                    small
-                    primary
-                    type="submit"
-                    loading={submitting}
-                    disabled={
-                        errors !== undefined && Object.keys(errors).length !== 0
-                    }
-                >
+                <Button small primary type="submit" loading={submitting}>
                     {submitting ? i18n.t('Saving...') : i18n.t('Save limits')}
                 </Button>
 


### PR DESCRIPTION
~~Adds a `touched`-check for validation so that the error-message does not show up before they have the user has a chance to prevent the error.~~

Errors are now hidden until the user has clicked "Save limits", and only shown if this fails. This is to prevent validation message showing up before user has a chance to prevent the error. After the first time submission fails, the validation will work like before. This is to make the error-message response once an error has occurred. 

I've enabled the `Save Limits`-button to prevent confusion, where the `Save limits`-button was disabled without an error message. Error message will show and stop submitting (updating minmax) if no valid limits.

I was also a bit confused about the bi-directional `'A min is required when providing a max` for both min and max-values. This basically just means that both values are required, right? Anyway I've updated that, since the disabled field is removed, it was possible to post empty-values - which results in 409 from the server.