### PR TITLE
ci: fix package.json name to ensure correct d2-ci deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "data-entry",
+    "name": "data-entry-app",
     "version": "1.0.0",
     "description": "",
     "license": "BSD-3-Clause",


### PR DESCRIPTION
The GitHub Actions workflow uses the name in `package.json` to determine the repository at https://github.com/d2-ci to push to, so this needs to match the package name.

The name/slug can be specified correctly as `data-entry` in `d2.config.js`